### PR TITLE
Change the order of construction of the parameters

### DIFF
--- a/Xabe.FFmpeg/Conversion.cs
+++ b/Xabe.FFmpeg/Conversion.cs
@@ -73,7 +73,7 @@ namespace Xabe.FFmpeg
                 builder.Append(BuildVideoFilter());
                 builder.Append(BuildAudioFilter());
                 builder.Append(_split);
-                builder.Append(_parameters.Aggregate("", (parameter, result) => result += parameter));
+                builder.Append(_parameters.Reverse().Aggregate("", (parameter, result) => result += parameter));
                 builder.Append(_output);
 
                 return builder.ToString();

--- a/Xabe.FFmpeg/Conversion.cs
+++ b/Xabe.FFmpeg/Conversion.cs
@@ -73,7 +73,7 @@ namespace Xabe.FFmpeg
                 builder.Append(BuildVideoFilter());
                 builder.Append(BuildAudioFilter());
                 builder.Append(_split);
-                builder.Append(_parameters.Reverse().Aggregate("", (parameter, result) => result += parameter));
+                builder.Append(_parameters.Aggregate("", (parameter, result) => result += parameter));
                 builder.Append(_output);
 
                 return builder.ToString();


### PR DESCRIPTION
Fixed an error in which the parameters are created from back to front and not in the order they are added.