### PR TITLE
Fixed an error in ConversionQueue

### DIFF
--- a/Xabe.FFmpeg.Test/ConversionQueueTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionQueueTests.cs
@@ -49,8 +49,10 @@ namespace Xabe.FFmpeg.Test
         {
             var queue = new ConversionQueue();
             var exceptionOccures = false;
+            var currentItemNumber = 0;
+            var totalItemsCount = 0;
 
-            for(var i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
                 string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + Extensions.Mp4);
                 File.Create(output);
@@ -62,10 +64,13 @@ namespace Xabe.FFmpeg.Test
             queue.OnException += (number, count, conversion) =>
             {
                 exceptionOccures = true;
-                resetEvent.Set();
+                totalItemsCount = count;
+                currentItemNumber = number;
+                if(number == count) resetEvent.Set();
             };
             queue.Start();
             Assert.True(resetEvent.WaitOne(2000));
+            Assert.Equal(totalItemsCount, currentItemNumber);
             Assert.True(exceptionOccures);
         }
     }

--- a/Xabe.FFmpeg.Test/ConversionQueueTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionQueueTests.cs
@@ -49,10 +49,8 @@ namespace Xabe.FFmpeg.Test
         {
             var queue = new ConversionQueue();
             var exceptionOccures = false;
-            var currentItemNumber = 0;
-            var totalItemsCount = 0;
 
-            for (var i = 0; i < 2; i++)
+            for(var i = 0; i < 2; i++)
             {
                 string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + Extensions.Mp4);
                 File.Create(output);
@@ -64,13 +62,10 @@ namespace Xabe.FFmpeg.Test
             queue.OnException += (number, count, conversion) =>
             {
                 exceptionOccures = true;
-                totalItemsCount = count;
-                currentItemNumber = number;
-                if(number == count) resetEvent.Set();
+                resetEvent.Set();
             };
             queue.Start();
             Assert.True(resetEvent.WaitOne(2000));
-            Assert.Equal(totalItemsCount, currentItemNumber);
             Assert.True(exceptionOccures);
         }
     }

--- a/Xabe.FFmpeg/ConversionQueue.cs
+++ b/Xabe.FFmpeg/ConversionQueue.cs
@@ -74,8 +74,8 @@ namespace Xabe.FFmpeg
                 {
                     _start.WaitOne();
                     conversion = GetNext();
-                    Interlocked.Increment(ref _number);
                     await conversion.Start(token);
+                    Interlocked.Increment(ref _number);
                     OnConverted?.Invoke((int) Interlocked.Read(ref _number), (int) Interlocked.Read(ref _totalItems), conversion);
                 }
                 catch(Exception)

--- a/Xabe.FFmpeg/ConversionQueue.cs
+++ b/Xabe.FFmpeg/ConversionQueue.cs
@@ -74,8 +74,8 @@ namespace Xabe.FFmpeg
                 {
                     _start.WaitOne();
                     conversion = GetNext();
-                    await conversion.Start(token);
                     Interlocked.Increment(ref _number);
+                    await conversion.Start(token);
                     OnConverted?.Invoke((int) Interlocked.Read(ref _number), (int) Interlocked.Read(ref _totalItems), conversion);
                 }
                 catch(Exception)


### PR DESCRIPTION
When a worker starts the conversion process and finds an error, it does not increase the _number field. This caused a difference with the number of files processed so it is not possible to know how many files are still queued and processed