### PR TITLE
Add FFMode to let user determine the running mode between FFmpeg FFpr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /.vs/*
 *.nupkg
 *.user
+*.userprefs

--- a/Xabe.FFmpeg/Enums/Mode.cs
+++ b/Xabe.FFmpeg/Enums/Mode.cs
@@ -1,0 +1,23 @@
+﻿namespace Xabe.FFmpeg.Enums
+{
+    /// <summary>
+    ///     Position on video
+    /// </summary>
+    public enum Mode
+    {
+        /// <summary>
+        ///     Upper left corner
+        /// </summary>
+        FFprobe,
+
+        /// <summary>
+        ///     Upper right corner
+        /// </summary>
+        FFmpeg,
+
+        /// <summary>
+        ///     Use FFmpeg and FFprobe
+        /// </summary>
+        All
+    }
+}

--- a/Xabe.FFmpeg/FFbase.cs
+++ b/Xabe.FFmpeg/FFbase.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xabe.FFmpeg.Enums;
 
 namespace Xabe.FFmpeg
 {
@@ -16,6 +17,13 @@ namespace Xabe.FFmpeg
     {
         private static string _ffmpegPath;
         private static string _ffprobePath;
+
+        /// <summary>
+        ///     Mode of FFbase
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once UnassignedField.Global
+        public static Mode FFmode = Mode.All;
 
         /// <summary>
         ///     Directory contains FFmpeg and FFprobe
@@ -60,14 +68,21 @@ namespace Xabe.FFmpeg
 
             if(!string.IsNullOrWhiteSpace(FFmpegDir))
             {
-                FFprobePath = new DirectoryInfo(FFmpegDir).GetFiles()
-                                                          .FirstOrDefault(x => x.Name.ToLower()
-                                                                                .Contains(FFprobeExecutableName.ToLower()))
-                                                          .FullName;
-                FFmpegPath = new DirectoryInfo(FFmpegDir).GetFiles()
-                                                         .FirstOrDefault(x => x.Name.ToLower()
-                                                                               .Contains(FFmpegExecutableName.ToLower()))
-                                                         .FullName;
+                if (FFmode == Mode.All || FFmode == Mode.FFprobe) {
+                    FFprobePath = new DirectoryInfo(FFmpegDir).GetFiles()
+                                          .FirstOrDefault(x => x.Name.ToLower()
+                                                                .Contains(FFprobeExecutableName.ToLower()))
+                                          .FullName;
+                }
+
+                if (FFmode == Mode.All || FFmode == Mode.FFmpeg)
+                {
+                    FFmpegPath = new DirectoryInfo(FFmpegDir).GetFiles()
+                                                             .FirstOrDefault(x => x.Name.ToLower()
+                                                                                   .Contains(FFmpegExecutableName.ToLower()))
+                                                             .FullName;
+                }
+
                 ValidateExecutables();
                 return;
             }
@@ -80,9 +95,18 @@ namespace Xabe.FFmpeg
 
                 FindProgramsFromPath(workingDirectory);
 
-                if (FFmpegPath != null &&
-                    FFprobePath != null)
-                    return;
+                switch (FFmode)
+                {
+                    case Mode.All:
+                        if (FFmpegPath != null && FFprobePath != null) return;
+                        break;
+                    case Mode.FFmpeg:
+                        if (FFmpegPath != null) return;
+                        break;
+                    case Mode.FFprobe:
+                        if (FFprobePath != null) return;
+                        break;
+                }
             }
 
             char splitChar = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ':' : ';';
@@ -94,9 +118,18 @@ namespace Xabe.FFmpeg
             {
                 FindProgramsFromPath(path);
 
-                if(FFmpegPath != null &&
-                   FFprobePath != null)
-                    break;
+                switch (FFmode)
+                {
+                    case Mode.All:
+                        if (FFmpegPath != null && FFprobePath != null) return;
+                        break;
+                    case Mode.FFmpeg:
+                        if (FFmpegPath != null) return;
+                        break;
+                    case Mode.FFprobe:
+                        if (FFprobePath != null) return;
+                        break;
+                }
             }
 
             ValidateExecutables();
@@ -146,9 +179,18 @@ namespace Xabe.FFmpeg
 
         private void ValidateExecutables()
         {
-            if(FFmpegPath != null &&
-               FFprobePath != null)
-                return;
+            switch (FFmode) {
+                case Mode.All: 
+                    if (FFmpegPath != null && FFprobePath != null) return;
+                    break;
+                case Mode.FFmpeg:
+                    if (FFmpegPath != null) return;
+                    break;
+                case Mode.FFprobe:
+                    if (FFprobePath != null) return;
+                    break;
+            }
+
 
             string ffmpegDir = string.IsNullOrWhiteSpace(FFmpegDir) ? "" : string.Format(FFmpegDir + " or ");
             string exceptionMessage =

--- a/Xabe.FFmpeg/Xabe.FFmpeg.csproj
+++ b/Xabe.FFmpeg/Xabe.FFmpeg.csproj
@@ -15,7 +15,6 @@
     <PackageTags>media converter audio ffmpeg wrapper core video encode decode</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
     <SignAssembly>false</SignAssembly>
-    <DelaySign>false</DelaySign>
     <PackageIconUrl>https://raw.githubusercontent.com/tomaszzmuda/Xabe.FFmpeg/master/Assets/icon_white.png</PackageIconUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
…obe and All to reduce the static lib needs.

If developers use the static lib from https://evermeet.cx/ffmpeg/
Xabe will require developer to pack ffmpeg(40MB+) and ffprobe(40MB+) both by default which they may don't need these two libs both in some cases.

So I added a FFmode property to solve this.