### PR TITLE
Fixed bad parsed duration in FFmpeg.cs  #80

### DIFF
--- a/Xabe.FFmpeg/Enums/Extensions.cs
+++ b/Xabe.FFmpeg/Enums/Extensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 
 namespace Xabe.FFmpeg.Enums
@@ -55,15 +57,54 @@ namespace Xabe.FFmpeg.Enums
                                 .GetField(value.ToString());
 
             var attributes =
-                (DescriptionAttribute[]) fi.GetCustomAttributes(
+                (DescriptionAttribute[])fi.GetCustomAttributes(
                     typeof(DescriptionAttribute),
                     false);
 
-            if(attributes != null &&
+            if (attributes != null &&
                attributes.Length > 0)
                 return attributes[0].Description;
 
             return value.ToString();
+        }
+
+        /// <summary>
+        ///     Return ffmpeg formated time
+        /// </summary>
+        /// <param name="ts">TimeSpan</param>
+        /// <returns>FFmpeg formated time</returns>
+        public static string ToFFmpeg(this TimeSpan ts)
+        {
+            return ts.ToString();
+        }
+
+        /// <summary>
+        ///     Parse FFmpeg formated time
+        /// </summary>
+        /// <param name="text">FFmpeg time</param>
+        /// <returns>TimeSpan</returns>
+        public static TimeSpan ParseFFmpegTime(this string text)
+        {
+            List<string> parts = text.Split(':').Reverse().ToList();
+
+            int milliseconds = 0;
+            int seconds = 0;
+
+            if (parts[0].Contains('.'))
+            {
+                string[] secondsSplit = parts[0].Split('.');
+                seconds = int.Parse(secondsSplit[0]);
+                milliseconds = int.Parse(secondsSplit[1]);
+            }
+            else
+            {
+                seconds = int.Parse(parts[0]);
+            }
+
+            int minutes = int.Parse(parts[1]);
+            int hours = int.Parse(parts[2]);
+
+            return new TimeSpan(0, hours, minutes, seconds, milliseconds);
         }
     }
 }

--- a/Xabe.FFmpeg/Enums/Extensions.cs
+++ b/Xabe.FFmpeg/Enums/Extensions.cs
@@ -75,7 +75,12 @@ namespace Xabe.FFmpeg.Enums
         /// <returns>FFmpeg formated time</returns>
         public static string ToFFmpeg(this TimeSpan ts)
         {
-            return ts.ToString();
+            int milliseconds = ts.Milliseconds;
+            int seconds = ts.Seconds;
+            int minutes = ts.Minutes;
+            int hours = (int) ts.TotalHours;
+
+            return $"{hours:D}:{minutes:D2}:{seconds:D2}.{milliseconds:D3}";
         }
 
         /// <summary>

--- a/Xabe.FFmpeg/FFbase.cs
+++ b/Xabe.FFmpeg/FFbase.cs
@@ -54,11 +54,11 @@ namespace Xabe.FFmpeg
         /// </summary>
         protected FFbase()
         {
-            if(!string.IsNullOrWhiteSpace(FFprobePath) &&
+            if (!string.IsNullOrWhiteSpace(FFprobePath) &&
                !string.IsNullOrWhiteSpace(FFmpegPath))
                 return;
 
-            if(!string.IsNullOrWhiteSpace(FFmpegDir))
+            if (!string.IsNullOrWhiteSpace(FFmpegDir))
             {
                 FFprobePath = new DirectoryInfo(FFmpegDir).GetFiles()
                                                           .FirstOrDefault(x => x.Name.ToLower()
@@ -74,7 +74,7 @@ namespace Xabe.FFmpeg
 
             Assembly entryAssembly = Assembly.GetEntryAssembly();
 
-            if(entryAssembly != null)
+            if (entryAssembly != null)
             {
                 string workingDirectory = Path.GetDirectoryName(entryAssembly.Location);
 
@@ -90,11 +90,11 @@ namespace Xabe.FFmpeg
             string[] paths = Environment.GetEnvironmentVariable("PATH")
                                         .Split(splitChar);
 
-            foreach(string path in paths)
+            foreach (string path in paths)
             {
                 FindProgramsFromPath(path);
 
-                if(FFmpegPath != null &&
+                if (FFmpegPath != null &&
                    FFprobePath != null)
                     break;
             }
@@ -109,14 +109,14 @@ namespace Xabe.FFmpeg
         {
             get
             {
-                lock(_ffmpegPathLock)
+                lock (_ffmpegPathLock)
                 {
                     return _ffmpegPath;
                 }
             }
             private set
             {
-                lock(_ffmpegPathLock)
+                lock (_ffmpegPathLock)
                 {
                     _ffmpegPath = value;
                 }
@@ -130,14 +130,14 @@ namespace Xabe.FFmpeg
         {
             get
             {
-                lock(_ffprobePathLock)
+                lock (_ffprobePathLock)
                 {
                     return _ffprobePath;
                 }
             }
             private set
             {
-                lock(_ffprobePathLock)
+                lock (_ffprobePathLock)
                 {
                     _ffprobePath = value;
                 }
@@ -146,7 +146,7 @@ namespace Xabe.FFmpeg
 
         private void ValidateExecutables()
         {
-            if(FFmpegPath != null &&
+            if (FFmpegPath != null &&
                FFprobePath != null)
                 return;
 
@@ -158,7 +158,7 @@ namespace Xabe.FFmpeg
 
         private void FindProgramsFromPath(string path)
         {
-            if(!Directory.Exists(path))
+            if (!Directory.Exists(path))
                 return;
             FileInfo[] files = new DirectoryInfo(path).GetFiles();
 

--- a/Xabe.FFmpeg/FFmpeg.cs
+++ b/Xabe.FFmpeg/FFmpeg.cs
@@ -91,7 +91,7 @@ namespace Xabe.FFmpeg
             {
                 Match match = regex.Match(e.Data);
                 if(match.Success)
-                    OnProgress(TimeSpan.Parse(match.Value), _totalTime);
+                    OnProgress(ParseDuration(match.Value), _totalTime);
             }
         }
 
@@ -100,17 +100,17 @@ namespace Xabe.FFmpeg
             string t = GetArgumentValue("-t", args);
             if(!string.IsNullOrWhiteSpace(t))
             {
-                _totalTime = TimeSpan.Parse(t);
+                _totalTime = ParseDuration(t);
                 return;
             }
 
             Match match = regex.Match(e.Data);
-            _totalTime = TimeSpan.Parse(match.Value);
+            _totalTime = ParseDuration(match.Value);
 
 
             string ss = GetArgumentValue("-ss", args);
             if(!string.IsNullOrWhiteSpace(ss))
-                _totalTime -= TimeSpan.Parse(ss);
+                _totalTime -= ParseDuration(ss);
         }
 
         private string GetArgumentValue(string option, string args)
@@ -121,6 +121,30 @@ namespace Xabe.FFmpeg
             if(index >= 0)
                 return words[index + 1];
             return "";
+        }
+
+        private TimeSpan ParseDuration(string duration)
+        {
+            List<string> parts = duration.Split(':').Reverse().ToList();
+
+            int milliseconds = 0;
+            int seconds = 0;
+
+            if (parts[0].Contains('.'))
+            {
+                string[] secondsSplit = parts[0].Split('.');
+                seconds = int.Parse(secondsSplit[0]);
+                milliseconds = int.Parse(secondsSplit[1]);
+            }
+            else
+            {
+                seconds = int.Parse(parts[0]);
+            }
+
+            int minutes = int.Parse(parts[1]);
+            int hours = int.Parse(parts[2]);
+
+            return new TimeSpan(0, hours, minutes, seconds, milliseconds);
         }
     }
 }

--- a/Xabe.FFmpeg/FFmpeg.cs
+++ b/Xabe.FFmpeg/FFmpeg.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Xabe.FFmpeg.Enums;
 using Xabe.FFmpeg.Exceptions;
 
 namespace Xabe.FFmpeg
@@ -21,7 +22,7 @@ namespace Xabe.FFmpeg
     /// <summary>
     ///     Wrapper for FFmpeg
     /// </summary>
-    internal class FFmpeg: FFbase
+    internal class FFmpeg : FFbase
     {
         private const string TimeFormatRegex = @"\w\w:\w\w:\w\w";
         private List<string> _outputLog;
@@ -45,17 +46,17 @@ namespace Xabe.FFmpeg
 
                 RunProcess(args, FFmpegPath, true, true, true);
 
-                using(Process)
+                using (Process)
                 {
                     Process.ErrorDataReceived += (sender, e) => ProcessOutputData(e, args);
                     Process.BeginErrorReadLine();
                     cancellationToken.Register(() => { Process.StandardInput.Write("q"); });
                     Process.WaitForExit();
 
-                    if(cancellationToken.IsCancellationRequested)
+                    if (cancellationToken.IsCancellationRequested)
                         return false;
 
-                    if(Process.ExitCode != 0)
+                    if (Process.ExitCode != 0)
                         throw new ConversionException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
                 }
                 return true;
@@ -64,14 +65,14 @@ namespace Xabe.FFmpeg
 
         private void ProcessOutputData(DataReceivedEventArgs e, string args)
         {
-            if(e.Data == null)
+            if (e.Data == null)
                 return;
 
             OnDataReceived?.Invoke(this, e);
 
             _outputLog.Add(e.Data);
 
-            if(OnProgress == null)
+            if (OnProgress == null)
                 return;
 
             CalculateTime(e, args);
@@ -79,38 +80,38 @@ namespace Xabe.FFmpeg
 
         private void CalculateTime(DataReceivedEventArgs e, string args)
         {
-            if(e.Data.Contains("Duration: N/A"))
+            if (e.Data.Contains("Duration: N/A"))
                 return;
 
             var regex = new Regex(TimeFormatRegex);
-            if(e.Data.Contains("Duration"))
+            if (e.Data.Contains("Duration"))
             {
                 GetDuration(e, regex, args);
             }
-            else if(e.Data.Contains("frame"))
+            else if (e.Data.Contains("frame"))
             {
                 Match match = regex.Match(e.Data);
-                if(match.Success)
-                    OnProgress(ParseDuration(match.Value), _totalTime);
+                if (match.Success)
+                    OnProgress(match.Value.ParseFFmpegTime(), _totalTime);
             }
         }
 
         private void GetDuration(DataReceivedEventArgs e, Regex regex, string args)
         {
             string t = GetArgumentValue("-t", args);
-            if(!string.IsNullOrWhiteSpace(t))
+            if (!string.IsNullOrWhiteSpace(t))
             {
-                _totalTime = ParseDuration(t);
+                _totalTime = t.ParseFFmpegTime();
                 return;
             }
 
             Match match = regex.Match(e.Data);
-            _totalTime = ParseDuration(match.Value);
+            _totalTime = match.Value.ParseFFmpegTime();
 
 
             string ss = GetArgumentValue("-ss", args);
-            if(!string.IsNullOrWhiteSpace(ss))
-                _totalTime -= ParseDuration(ss);
+            if (!string.IsNullOrWhiteSpace(ss))
+                _totalTime -= ss.ParseFFmpegTime();
         }
 
         private string GetArgumentValue(string option, string args)
@@ -118,33 +119,9 @@ namespace Xabe.FFmpeg
             List<string> words = args.Split(' ')
                                      .ToList();
             int index = words.IndexOf(option);
-            if(index >= 0)
+            if (index >= 0)
                 return words[index + 1];
             return "";
-        }
-
-        private TimeSpan ParseDuration(string duration)
-        {
-            List<string> parts = duration.Split(':').Reverse().ToList();
-
-            int milliseconds = 0;
-            int seconds = 0;
-
-            if (parts[0].Contains('.'))
-            {
-                string[] secondsSplit = parts[0].Split('.');
-                seconds = int.Parse(secondsSplit[0]);
-                milliseconds = int.Parse(secondsSplit[1]);
-            }
-            else
-            {
-                seconds = int.Parse(parts[0]);
-            }
-
-            int minutes = int.Parse(parts[1]);
-            int hours = int.Parse(parts[2]);
-
-            return new TimeSpan(0, hours, minutes, seconds, milliseconds);
         }
     }
 }


### PR DESCRIPTION
This is a workaround for this problem. It is still necessary to verify the use of TimeSpan for the generation of times in other parts of the code, I know that this version is closed, but it is a bug that affects this and the next version of this library.