### PR TITLE
Default preset and multithread

### DIFF
--- a/Xabe.FFmpeg.Test/ConversionHelperTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionHelperTests.cs
@@ -19,8 +19,7 @@ namespace Xabe.FFmpeg.Test
             string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Gif);
 
             IConversionResult result = await (await Conversion.ToGif(Resources.Mp4, output, loopCount, delay))
-                                             .UseMultiThread(true)
-                                             .SetSpeed(ConversionSpeed.UltraFast)
+                                             .SetPreset(ConversionPreset.UltraFast)
                                              .Start();
 
             Assert.True(result.Success);
@@ -103,8 +102,7 @@ namespace Xabe.FFmpeg.Test
 
             var language = "pol";
             IConversionResult result = await (await Conversion.AddSubtitle(input, output, Resources.SubtitleSrt, language))
-                                             .UseMultiThread(true)
-                                             .SetSpeed(ConversionSpeed.UltraFast)
+                                             .SetPreset(ConversionPreset.UltraFast)
                                              .Start();
 
             Assert.True(result.Success);
@@ -124,8 +122,7 @@ namespace Xabe.FFmpeg.Test
             string input = Resources.Mp4;
 
             IConversionResult result = await (await Conversion.AddSubtitles(input, output, Resources.SubtitleSrt))
-                                             .UseMultiThread(true)
-                                             .SetSpeed(ConversionSpeed.UltraFast)
+                                             .SetPreset(ConversionPreset.UltraFast)
                                              .Start();
 
             Assert.True(result.Success);
@@ -295,8 +292,7 @@ namespace Xabe.FFmpeg.Test
             string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.WebM);
 
             IConversionResult result = await (await Conversion.ToWebM(Resources.Mp4WithAudio, output))
-                                             .SetSpeed(ConversionSpeed.UltraFast)
-                                             .UseMultiThread(true)
+                                             .SetPreset(ConversionPreset.UltraFast)
                                              .Start();
 
             Assert.True(result.Success);
@@ -317,7 +313,6 @@ namespace Xabe.FFmpeg.Test
         {
             string output = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mp4);
             IConversionResult result = await (await Conversion.SetWatermark(Resources.Mp4WithAudio, output, Resources.PngSample, Position.Center))
-                                             .UseMultiThread(true)
                                              .Start();
 
             Assert.True(result.Success);

--- a/Xabe.FFmpeg.Test/ConversionResultTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionResultTests.cs
@@ -13,8 +13,7 @@ namespace Xabe.FFmpeg.Test
             string outputPath = Path.ChangeExtension(Path.GetTempFileName(), ".mp4");
 
             IConversionResult result = await (await Conversion.ToMp4(Resources.Mp4WithAudio, outputPath))
-                                             .UseMultiThread(true)
-                                             .SetSpeed(Enums.ConversionSpeed.UltraFast)
+                                             .SetPreset(Enums.ConversionPreset.UltraFast)
                                              .Start();
 
             Assert.True(result.Success);

--- a/Xabe.FFmpeg.Test/ConversionTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionTests.cs
@@ -64,7 +64,7 @@
 //            string outputPath = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mp4);
 //            bool conversionResult = await Conversion.New()
 //                                                    .SetInput(Resources.MkvWithAudio)
-//                                                    .SetSpeed(Speed.UltraFast)
+//                                                    .SetPreset(Speed.UltraFast)
 //                                                    .UseMultiThread(true)
 //                                                    .SetOutput(outputPath)
 //                                                    .SetCodec(VideoCodec.h264, 2400)
@@ -90,7 +90,7 @@
 
 //            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await Conversion.New()
 //                                                                                              .SetInput(Resources.MkvWithAudio)
-//                                                                                              .SetSpeed(Speed.UltraFast)
+//                                                                                              .SetPreset(Speed.UltraFast)
 //                                                                                              .UseMultiThread(true)
 //                                                                                              .SetOutput(outputPath)
 //                                                                                              .SetCodec(VideoCodec.h264, 2400)
@@ -433,7 +433,7 @@
 //            string outputPath = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mp4);
 //            bool conversionResult = await Conversion.New()
 //                                                    .SetInput(Resources.MkvWithAudio)
-//                                                    .SetSpeed(Speed.UltraFast)
+//                                                    .SetPreset(Speed.UltraFast)
 //                                                    .UseMultiThread(true)
 //                                                    .SetOutput(outputPath)
 //                                                    .SetCodec(VideoCodec.h264, 2400)
@@ -454,7 +454,7 @@
 //            string outputPath = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mp4);
 //            bool conversionResult = await Conversion.New()
 //                                                    .SetInput(Resources.MkvWithAudio)
-//                                                    .SetSpeed(Speed.UltraFast)
+//                                                    .SetPreset(Speed.UltraFast)
 //                                                    .UseMultiThread(true)
 //                                                    .SetOutput(outputPath)
 //                                                    .SetScale(VideoSize.Sqcif)
@@ -578,7 +578,7 @@
 //                .SetCodec(VideoCodec.theora, 2400)
 //                .SetCodec(AudioCodec.libvorbis, AudioQuality.Ultra)
 //                .SetOutput(outputPath)
-//                .SetSpeed(Speed.VerySlow)
+//                .SetPreset(Speed.VerySlow)
 //                .UseMultiThread(false)
 //                .Start(cancellationTokenSource.Token);
 
@@ -599,7 +599,7 @@
 //                .SetCodec(VideoCodec.theora, 2400)
 //                .SetCodec(AudioCodec.libvorbis, AudioQuality.Ultra)
 //                .SetOutput(outputPath)
-//                .SetSpeed(Speed.VerySlow)
+//                .SetPreset(Speed.VerySlow)
 //                .UseMultiThread(false)
 //                .Start(cancellationTokenSource.Token);
 

--- a/Xabe.FFmpeg.Test/SubtitleTests.cs
+++ b/Xabe.FFmpeg.Test/SubtitleTests.cs
@@ -24,8 +24,7 @@ namespace Xabe.FFmpeg.Test
             IConversionResult result = await Conversion.New()
                                           .AddStream(subtitleStream)
                                           .SetOutput(outputPath)
-                                          .UseMultiThread(true)
-                                          .SetSpeed(ConversionSpeed.UltraFast)
+                                          .SetPreset(ConversionPreset.UltraFast)
                                           .Start();
 
             Assert.True(result.Success);

--- a/Xabe.FFmpeg.Test/VideoStreamTests.cs
+++ b/Xabe.FFmpeg.Test/VideoStreamTests.cs
@@ -42,8 +42,7 @@ namespace Xabe.FFmpeg.Test
 
             IConversionResult conversionResult = await Conversion.New()
                                                     .AddStream(inputFile.VideoStreams.First().SetCodec(VideoCodec.h264).ChangeSpeed(speed))
-                                                    .SetSpeed(ConversionSpeed.UltraFast)
-                                                    .UseMultiThread(true)
+                                                    .SetPreset(ConversionPreset.UltraFast)
                                                     .SetOutput(outputPath)
                                                     .Start();
 
@@ -67,8 +66,7 @@ namespace Xabe.FFmpeg.Test
                                                                                               .AddStream(inputFile.VideoStreams.First()
                                                                                                                   .SetCodec(VideoCodec.h264)
                                                                                                                   .ChangeSpeed(multiplication))
-                                                                                              .SetSpeed(ConversionSpeed.UltraFast)
-                                                                                              .UseMultiThread(true)
+                                                                                              .SetPreset(ConversionPreset.UltraFast)
                                                                                               .SetOutput(outputPath)
                                                                                               .Start());
         }
@@ -197,8 +195,7 @@ namespace Xabe.FFmpeg.Test
                                                    .AddStream(inputFile.VideoStreams.First()
                                                                                     .SetCodec(VideoCodec.h264)
                                                                                     .Reverse())
-                                                   .SetSpeed(ConversionSpeed.UltraFast)
-                                                   .UseMultiThread(true)
+                                                   .SetPreset(ConversionPreset.UltraFast)
                                                    .SetOutput(outputPath)
                                                    .Start();
 
@@ -219,8 +216,7 @@ namespace Xabe.FFmpeg.Test
                                                    .AddStream(inputFile.VideoStreams.First()
                                                                                      .SetScale(VideoSize.Sqcif)
                                                                                      .SetCodec(VideoCodec.h264))
-                                                   .SetSpeed(ConversionSpeed.UltraFast)
-                                                   .UseMultiThread(true)
+                                                   .SetPreset(ConversionPreset.UltraFast)
                                                    .SetOutput(outputPath)
                                                    .Start();
 

--- a/Xabe.FFmpeg/Enums/ConversionPreset.cs
+++ b/Xabe.FFmpeg/Enums/ConversionPreset.cs
@@ -1,9 +1,9 @@
 ﻿namespace Xabe.FFmpeg.Enums
 {
     /// <summary>
-    ///     Speed of conversion. Faster speed causes worse optimization and quality.
+    ///     Preset of conversion. Faster speed causes worse optimization and quality.
     /// </summary>
-    public enum ConversionSpeed
+    public enum ConversionPreset
     {
         /// <summary>
         ///     Very slow

--- a/Xabe.FFmpeg/IConversion.cs
+++ b/Xabe.FFmpeg/IConversion.cs
@@ -32,11 +32,11 @@ namespace Xabe.FFmpeg
         void Clear();
 
         /// <summary>
-        ///     Set speed of IConversion. Slower speed equals better compression and quality.
+        ///     Set preset of IConversion. Slower speed equals better compression and quality.
         /// </summary>
-        /// <param name="speed">Speed</param>
+        /// <param name="preset">Preset</param>
         /// <returns>IConversion object</returns>
-        IConversion SetSpeed(ConversionSpeed speed);
+        IConversion SetPreset(ConversionPreset preset);
 
         /// <summary>
         ///     Defines if converter should use all CPU cores

--- a/Xabe.FFmpeg/MediaInfo.cs
+++ b/Xabe.FFmpeg/MediaInfo.cs
@@ -15,35 +15,23 @@ namespace Xabe.FFmpeg
             FileInfo = fileInfo;
         }
 
-        /// <summary>
-        ///     All file streams
-        /// </summary>
+        /// <inheritdoc />
         public IEnumerable<IStream> Streams => VideoStreams.Concat<IStream>(AudioStreams)
                                                            .Concat(SubtitleStreams);
 
-        /// <summary>
-        ///     Duration of media
-        /// </summary>
+        /// <inheritdoc />
         public TimeSpan Duration { get; internal set; }
 
-        /// <summary>
-        ///     Size of file
-        /// </summary>
+        /// <inheritdoc />
         public long Size { get; internal set; }
 
-        /// <summary>
-        ///     Video streams
-        /// </summary>
+        /// <inheritdoc />
         public IEnumerable<IVideoStream> VideoStreams { get; internal set; }
 
-        /// <summary>
-        ///     Audio streams
-        /// </summary>
+        /// <inheritdoc />
         public IEnumerable<IAudioStream> AudioStreams { get; internal set; }
 
-        /// <summary>
-        ///     Subtitle streams
-        /// </summary>
+        /// <inheritdoc />
         public IEnumerable<ISubtitleStream> SubtitleStreams { get; internal set; }
 
         /// <inheritdoc />

--- a/Xabe.FFmpeg/Streams/VideoStream.cs
+++ b/Xabe.FFmpeg/Streams/VideoStream.cs
@@ -57,13 +57,6 @@ namespace Xabe.FFmpeg
         }
 
         /// <inheritdoc />
-        public IVideoStream SetPresset(ConversionSpeed speed)
-        {
-            _preset = $"-preset {speed.ToString().ToLower()} ";
-            return this;
-        }
-
-        /// <inheritdoc />
         public IVideoStream ChangeSpeed(double multiplication)
         {
             _speed = MediaSpeedHelper.GetVideoSpeed(multiplication);


### PR DESCRIPTION
SetSpeed is bad choice. In ffmpeg it is preset because it is no only speed but a few parameters and change conversion speed, quality and size. Set that to the faster option is bad idea. No one want bad quality by default.

I set multithread by default.