### PR TITLE
FFprobeWrapper GetVideoAspectRation Crash when splitted video get probed

### DIFF
--- a/Xabe.FFmpeg/FFprobeWrapper.cs
+++ b/Xabe.FFmpeg/FFprobeWrapper.cs
@@ -28,10 +28,14 @@ namespace Xabe.FFmpeg
             return Math.Round(double.Parse(fr[0]) / double.Parse(fr[1]), 3);
         }
 
-        private string GetVideoAspectRatio(int width, int heigght)
+        private string GetVideoAspectRatio(int width, int height)
         {
-            int cd = GetGcd(width, heigght);
-            return width / cd + ":" + heigght / cd;
+            int cd = GetGcd(width, height);
+            if(cd <= 0)
+            {
+                return "0:0";
+            }
+            return width / cd + ":" + height / cd;
         }
 
         private async Task<FormatModel.Format> GetFormat(string videoPath)


### PR DESCRIPTION
Can not write unit test without media file. I won't change methods visibility to test it. 