### PR TITLE
 Fix FFmpegDownloader files overwrite and missing executables scenarios

### DIFF
--- a/Xabe.FFmpeg/Downloader/FFmpegDownloader.cs
+++ b/Xabe.FFmpeg/Downloader/FFmpegDownloader.cs
@@ -77,7 +77,7 @@ namespace Xabe.FFmpeg.Downloader
 
         private static bool CheckIfFilesExist()
         {
-            return !File.Exists(FfmpegDestinationPath) && !File.Exists(FfprobeDestinationPath);
+            return !File.Exists(FfmpegDestinationPath) || !File.Exists(FfprobeDestinationPath);
         }
 
         internal static string ComputeFileDestinationPath(string filename, OperatingSystem os)

--- a/Xabe.FFmpeg/Downloader/FFmpegDownloader.cs
+++ b/Xabe.FFmpeg/Downloader/FFmpegDownloader.cs
@@ -39,8 +39,6 @@ namespace Xabe.FFmpeg.Downloader
 
         internal async static Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries)
         {
-            var ffProbeZipPath = Path.Combine(Path.GetTempPath(), "FFprobe.zip");
-
             Links links = _linkProvider.GetLinks(latestFFmpegBinaries);
 
             var ffmpegZip = await DownloadFile(links.FFmpegLink);


### PR DESCRIPTION
`FFmpeg.GetLatestVersion()` fail when there is a FFmpeg new version because `ZipFile.ExtractToDirectory` throw an IOException when there is already existing files.

My changes handle it by using `zipEntry.ExtractToFile` on each ZipArchiveEntry with the overwrite option.

I also handle scenarios where FFmpeg executables are missing. They were not downloaded again because only the version.json file was checked.

I added unit tests for all of that.