### PR TITLE
Implement Setting Audio and Video Bitrate #89

### DIFF
--- a/Xabe.FFmpeg.Test/ConversionTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionTests.cs
@@ -81,6 +81,86 @@ namespace Xabe.FFmpeg.Test
         }
 
         [Fact]
+        public async Task SetAudioBitrateTest()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+            IMediaInfo info = await MediaInfo.Get(Resources.MkvWithAudio).ConfigureAwait(false);
+            IAudioStream audioStream = info.AudioStreams.First()?.SetCodec(AudioCodec.Ac3);
+
+            IConversionResult conversionResult = await Conversion.New()
+                                                                 .AddStream(audioStream)
+                                                                 .SetAudioBitrate("128K")
+                                                                 .SetOutput(output)
+                                                                 .Start().ConfigureAwait(false);
+
+            double lowerBound = 128000 * 0.95;
+            double upperBound = 128000 * 1.05;
+            Assert.True(conversionResult.Success);
+            IMediaInfo resultFile = conversionResult.MediaInfo.Value;
+            Assert.InRange<double>(resultFile.AudioStreams.First().Bitrate, lowerBound, upperBound);
+        }
+
+        [Fact]
+        public async Task SetLibH264VideoBitrateTest()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+            IMediaInfo info = await MediaInfo.Get(Resources.MkvWithAudio).ConfigureAwait(false);
+            IVideoStream videoStream = info.VideoStreams.First()?.SetCodec(VideoCodec.Libx264);
+
+            IConversionResult conversionResult = await Conversion.New()
+                                                                 .AddStream(videoStream)
+                                                                 .SetVideoBitrate("1500K")
+                                                                 .SetOutput(output)
+                                                                 .Start().ConfigureAwait(false);
+
+            double lowerBound = 1500000 * 0.95;
+            double upperBound = 1500000 * 1.05;
+            Assert.True(conversionResult.Success);
+            IMediaInfo resultFile = conversionResult.MediaInfo.Value;
+            Assert.InRange<double>(resultFile.VideoStreams.First().Bitrate, lowerBound, upperBound);
+        }
+
+        [Fact]
+        public async Task SetH264VideoBitrateTest()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+            IMediaInfo info = await MediaInfo.Get(Resources.MkvWithAudio).ConfigureAwait(false);
+            IVideoStream videoStream = info.VideoStreams.First()?.SetCodec(VideoCodec.H264);
+
+            IConversionResult conversionResult = await Conversion.New()
+                                                                 .AddStream(videoStream)
+                                                                 .SetVideoBitrate("1500K")
+                                                                 .SetOutput(output)
+                                                                 .Start().ConfigureAwait(false);
+
+            double lowerBound = 1500000 * 0.95;
+            double upperBound = 1500000 * 1.05;
+            Assert.True(conversionResult.Success);
+            IMediaInfo resultFile = conversionResult.MediaInfo.Value;
+            Assert.InRange<double>(resultFile.VideoStreams.First().Bitrate, lowerBound, upperBound);
+        }
+
+        [Fact]
+        public async Task SetNonH264VideoBitrateTest()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+            IMediaInfo info = await MediaInfo.Get(Resources.MkvWithAudio).ConfigureAwait(false);
+            IVideoStream videoStream = info.VideoStreams.First()?.SetCodec(VideoCodec.Mpeg4);
+
+            IConversionResult conversionResult = await Conversion.New()
+                                                                 .AddStream(videoStream)
+                                                                 .SetVideoBitrate("1500K")
+                                                                 .SetOutput(output)
+                                                                 .Start().ConfigureAwait(false);
+
+            double lowerBound = 1500000 * 0.95;
+            double upperBound = 1500000 * 1.05;
+            Assert.True(conversionResult.Success);
+            IMediaInfo resultFile = conversionResult.MediaInfo.Value;
+            Assert.InRange<double>(resultFile.VideoStreams.First().Bitrate, lowerBound, upperBound);
+        }
+
+        [Fact]
         public async Task OverwriteFilesTest()
         {
             string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);

--- a/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -186,6 +186,27 @@ namespace Xabe.FFmpeg
         }
 
         /// <inheritdoc />
+        public IConversion SetVideoBitrate(string bitrate)
+        {
+            AddParameter(string.Format("-b:v {0}", bitrate));
+            AddParameter(string.Format("-minrate {0}", bitrate));
+            AddParameter(string.Format("-maxrate {0}", bitrate));
+            AddParameter(string.Format("-bufsize {0}", bitrate));
+
+            if (HasH264Stream())
+                AddParameter("-x264opts nal-hrd=cbr:force-cfr=1");
+            
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IConversion SetAudioBitrate(string bitrate)
+        {
+            AddParameter(string.Format("-b:a {0}", bitrate));
+            return this;
+        }
+
+        /// <inheritdoc />
         public IConversion UseShortest(bool useShortest)
         {
             _shortestInput = !useShortest ? string.Empty : "-shortest ";
@@ -326,6 +347,23 @@ namespace Xabe.FFmpeg
             return builder.ToString();
         }
 
+        private bool HasH264Stream()
+        {
+            foreach (IStream stream in _streams)
+            {
+                if (stream is IVideoStream)
+                {
+                    IVideoStream s = (IVideoStream)stream;
+                    VideoCodec codec = s.GetCodec();
+                    if (codec.ToString() == VideoCodec.Libx264.ToString() ||
+                        codec.ToString() == VideoCodec.H264.ToString())
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
         /// <summary>
         ///     Get new instance of Conversion
         /// </summary>

--- a/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -380,7 +380,7 @@ namespace Xabe.FFmpeg
                 if (stream is IVideoStream)
                 {
                     IVideoStream s = (IVideoStream)stream;
-                    VideoCodec codec = s.GetCodec();
+                    VideoCodec codec = ((VideoStream)s).Codec;
                     if (codec.ToString() == VideoCodec.Libx264.ToString() ||
                         codec.ToString() == VideoCodec.H264.ToString())
                     {

--- a/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -52,6 +52,22 @@ namespace Xabe.FFmpeg
         IConversion SetPreset(ConversionPreset preset);
 
         /// <summary>
+        ///     Sets The bitrate of the video streams to the supplied value
+        ///     Acceptable values include 1200K for 1200kbit/s or 1M for 1mbit/s
+        /// </summary>
+        /// <param name="bitrate">The required Bitrate Value</param>
+        /// <returns>IConversion object</returns>
+        IConversion SetVideoBitrate(string bitrate);
+
+        /// <summary>
+        ///     Sets The bitrate of the audio streams to the supplied value
+        ///     Acceptable values include 1200K for 1200kbit/s or 1M for 1mbit/s
+        /// </summary>
+        /// <param name="bitrate">The required Bitrate Value</param>
+        /// <returns>IConversion object</returns>
+        IConversion SetAudioBitrate(string bitrate);
+
+        /// <summary>
         ///     Defines thread count used by converter
         /// </summary>
         /// <param name="threadCount">Number of used threads</param>

--- a/Xabe.FFmpeg/Enums/VideoCodec.cs
+++ b/Xabe.FFmpeg/Enums/VideoCodec.cs
@@ -56,6 +56,11 @@
         /// </summary>
         public static readonly VideoCodec H264_nvenc = new VideoCodec("h264_nvenc");
 
+        /// <summary>
+        ///     Copy
+        /// </summary>
+        public static readonly VideoCodec Copy = new VideoCodec("copy");
+
         /// <inheritdoc />
         public VideoCodec(string codec)
         {

--- a/Xabe.FFmpeg/FFprobeWrapper.cs
+++ b/Xabe.FFmpeg/FFprobeWrapper.cs
@@ -159,7 +159,8 @@ namespace Xabe.FFmpeg
                     Format = model.codec_name,
                     Duration = GetAudioDuration(model),
                     Source = fileInfo,
-                    Index = model.index
+                    Index = model.index,
+                    Bitrate = Math.Abs(model.bit_rate)
                 };
                 yield return stream;
             }

--- a/Xabe.FFmpeg/Streams/AudioStream.cs
+++ b/Xabe.FFmpeg/Streams/AudioStream.cs
@@ -12,7 +12,6 @@ namespace Xabe.FFmpeg.Streams
     public class AudioStream : IAudioStream, IFilterable
     {
         private readonly Dictionary<string, string> _audioFilters = new Dictionary<string, string>();
-        private string _audio;
         private string _bitsreamFilter;
         private string _reverse;
         private string _seek;
@@ -29,7 +28,7 @@ namespace Xabe.FFmpeg.Streams
         public string Build()
         {
             var builder = new StringBuilder();
-            builder.Append(_audio);
+            builder.Append(BuildAudioCodec());
             builder.Append(_bitsreamFilter);
             builder.Append(_reverse);
             builder.Append(_split);
@@ -40,6 +39,15 @@ namespace Xabe.FFmpeg.Streams
         public string BuildInputArguments()
         {
             return _seek;
+        }
+
+        /// <inheritdoc />
+        public string BuildAudioCodec()
+        {
+            if (Codec != null)
+                return $"-c:a {Codec.ToString()} ";
+            else
+                return string.Empty;
         }
 
         /// <inheritdoc />
@@ -76,7 +84,7 @@ namespace Xabe.FFmpeg.Streams
         /// <inheritdoc />
         public IAudioStream SetCodec(AudioCodec codec)
         {
-            _audio = $"-codec:a {codec} ";
+            Codec = codec;
             return this;
         }
 
@@ -91,6 +99,9 @@ namespace Xabe.FFmpeg.Streams
 
         /// <inheritdoc />
         public double Bitrate { get; set; }
+
+        /// <inheritdoc />
+        public AudioCodec Codec { get; private set; }
 
         /// <inheritdoc />
         public IEnumerable<string> GetSource()
@@ -109,12 +120,6 @@ namespace Xabe.FFmpeg.Streams
                 _seek = $"-ss {seek.Value.ToFFmpeg()} ";
             }
             return this;
-        }
-
-        /// <inheritdoc />
-        public AudioCodec GetCodec()
-        {
-            return new AudioCodec(_audio.Replace("-codec:a ", "").Trim(' '));
         }
 
         void ILocalStream.Split(TimeSpan startTime, TimeSpan duration)

--- a/Xabe.FFmpeg/Streams/AudioStream.cs
+++ b/Xabe.FFmpeg/Streams/AudioStream.cs
@@ -90,6 +90,9 @@ namespace Xabe.FFmpeg.Streams
         public string Format { get; internal set; }
 
         /// <inheritdoc />
+        public double Bitrate { get; set; }
+
+        /// <inheritdoc />
         public IEnumerable<string> GetSource()
         {
             return new[] { Source.FullName };
@@ -106,6 +109,12 @@ namespace Xabe.FFmpeg.Streams
                 _seek = $"-ss {seek.Value.ToFFmpeg()} ";
             }
             return this;
+        }
+
+        /// <inheritdoc />
+        public AudioCodec GetCodec()
+        {
+            return new AudioCodec(_audio.Replace("-codec:a ", "").Trim(' '));
         }
 
         void ILocalStream.Split(TimeSpan startTime, TimeSpan duration)

--- a/Xabe.FFmpeg/Streams/IAudioStream.cs
+++ b/Xabe.FFmpeg/Streams/IAudioStream.cs
@@ -19,6 +19,12 @@ namespace Xabe.FFmpeg.Streams
         CodecType CodecType { get; }
 
         /// <summary>
+        ///     Bit Rate
+        /// </summary>
+        double Bitrate { get; set; }
+
+
+        /// <summary>
         ///     Set stream to copy with orginal codec
         /// </summary>
         /// <returns>IAudioStream</returns>
@@ -66,5 +72,11 @@ namespace Xabe.FFmpeg.Streams
         /// <param name="seek">Position</param>
         /// <returns>IAudioStream</returns>
         IAudioStream SetSeek(TimeSpan? seek);
+        
+        /// <summary>
+        /// Gets Audio Codec for stream
+        /// </summary>
+        /// <returns></returns>
+        AudioCodec GetCodec();
     }
 }

--- a/Xabe.FFmpeg/Streams/IAudioStream.cs
+++ b/Xabe.FFmpeg/Streams/IAudioStream.cs
@@ -23,7 +23,6 @@ namespace Xabe.FFmpeg.Streams
         /// </summary>
         double Bitrate { get; set; }
 
-
         /// <summary>
         ///     Set stream to copy with orginal codec
         /// </summary>
@@ -72,11 +71,5 @@ namespace Xabe.FFmpeg.Streams
         /// <param name="seek">Position</param>
         /// <returns>IAudioStream</returns>
         IAudioStream SetSeek(TimeSpan? seek);
-        
-        /// <summary>
-        /// Gets Audio Codec for stream
-        /// </summary>
-        /// <returns></returns>
-        AudioCodec GetCodec();
     }
 }

--- a/Xabe.FFmpeg/Streams/IVideoStream.cs
+++ b/Xabe.FFmpeg/Streams/IVideoStream.cs
@@ -129,12 +129,6 @@ namespace Xabe.FFmpeg.Streams
         IVideoStream SetSeek(TimeSpan seek);
 
         /// <summary>
-        /// Gets Video Codec for stream
-        /// </summary>
-        /// <returns></returns>
-        VideoCodec GetCodec();
-
-        /// <summary>
         ///     Burn subtitle into file
         /// </summary>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>

--- a/Xabe.FFmpeg/Streams/IVideoStream.cs
+++ b/Xabe.FFmpeg/Streams/IVideoStream.cs
@@ -129,6 +129,12 @@ namespace Xabe.FFmpeg.Streams
         IVideoStream SetSeek(TimeSpan seek);
 
         /// <summary>
+        /// Gets Video Codec for stream
+        /// </summary>
+        /// <returns></returns>
+        VideoCodec GetCodec();
+
+        /// <summary>
         ///     Burn subtitle into file
         /// </summary>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>

--- a/Xabe.FFmpeg/Streams/VideoStream.cs
+++ b/Xabe.FFmpeg/Streams/VideoStream.cs
@@ -14,7 +14,6 @@ namespace Xabe.FFmpeg.Streams
         private readonly Dictionary<string, string> _videoFilters = new Dictionary<string, string>();
         private string _watermarkSource;
         private string _bitsreamFilter;
-        private string _codec;
         private string _frameCount;
         private string _loop;
         private string _reverse;
@@ -52,6 +51,9 @@ namespace Xabe.FFmpeg.Streams
 
         /// <inheritdoc />
         public FileInfo Source { get; internal set; }
+        
+        /// <inheritdoc />
+        public VideoCodec Codec { get; private set; }
 
         /// <inheritdoc />
         public string Build()
@@ -59,7 +61,7 @@ namespace Xabe.FFmpeg.Streams
             var builder = new StringBuilder();
             builder.Append(string.Join(" ", _parameters));
             builder.Append(_scale);
-            builder.Append(_codec);
+            builder.Append(BuildVideoCodec());
             builder.Append(_bitsreamFilter);
             builder.Append(_frameCount);
             builder.Append(_loop);
@@ -74,6 +76,15 @@ namespace Xabe.FFmpeg.Streams
         public string BuildInputArguments()
         {
             return _seek;
+        }
+
+        /// <inheritdoc />
+        public string BuildVideoCodec()
+        {
+            if (Codec != null)
+                return $"-c:v {Codec.ToString()} ";
+            else
+                return string.Empty;
         }
 
         /// <inheritdoc />
@@ -99,7 +110,7 @@ namespace Xabe.FFmpeg.Streams
         /// <inheritdoc />
         public IVideoStream CopyStream()
         {
-            _codec = "-c:v copy ";
+            Codec = VideoCodec.Copy;
             return this;
         }
 
@@ -165,7 +176,7 @@ namespace Xabe.FFmpeg.Streams
         /// <inheritdoc />
         public IVideoStream SetCodec(VideoCodec codec)
         {
-            _codec = $"-codec:v {codec} ";
+            Codec = codec;
             return this;
         }
 
@@ -200,7 +211,7 @@ namespace Xabe.FFmpeg.Streams
         /// <inheritdoc />
         public VideoCodec GetCodec()
         {
-            return new VideoCodec(_codec.Replace("-codec:v ", "").Trim(' '));
+            return Codec;
         }
 
         /// <inheritdoc />

--- a/Xabe.FFmpeg/Streams/VideoStream.cs
+++ b/Xabe.FFmpeg/Streams/VideoStream.cs
@@ -209,12 +209,6 @@ namespace Xabe.FFmpeg.Streams
         }
 
         /// <inheritdoc />
-        public VideoCodec GetCodec()
-        {
-            return Codec;
-        }
-
-        /// <inheritdoc />
         public TimeSpan Duration { get; internal set; }
 
         /// <inheritdoc />

--- a/Xabe.FFmpeg/Streams/VideoStream.cs
+++ b/Xabe.FFmpeg/Streams/VideoStream.cs
@@ -198,6 +198,12 @@ namespace Xabe.FFmpeg.Streams
         }
 
         /// <inheritdoc />
+        public VideoCodec GetCodec()
+        {
+            return new VideoCodec(_codec.Replace("-codec:v ", "").Trim(' '));
+        }
+
+        /// <inheritdoc />
         public TimeSpan Duration { get; internal set; }
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR Implements setting of Audio and Video bitrate. This Method seems to work on all audio and video codecs apart from `H264` and `libx264` that requires this special parameter.

`"-x264opts nal-hrd=cbr:force-cfr=1"` 

Without this parameter the encoder seems to ignore all other bitrate setting options. Not sure if this is an issue that should be raised with the FFmpeg team or if this is the intended behaviour.

To facilitate this I have had to implement a method that gets the codec of the video streams in the conversion and if any of them are `H264` or`libx264` set this parameter when setting bitrate.

As per the unit test this method is accurate to within 5% of the supplied values for both audio and video.

Fixes #89 