### PR TITLE
Add Workaround for Issue #201

### DIFF
--- a/Xabe.FFmpeg.Test/ConversionHelperTests.cs
+++ b/Xabe.FFmpeg.Test/ConversionHelperTests.cs
@@ -164,6 +164,8 @@ namespace Xabe.FFmpeg.Test
             IAudioStream audioStream = mediaInfo.AudioStreams.First();
             Assert.NotNull(audioStream);
             Assert.Equal("mp3", audioStream.Format);
+            Assert.Equal(TimeSpan.FromSeconds(13), audioStream.Duration);
+            Assert.Equal(320000, audioStream.Bitrate);
         }
 
         [Fact]

--- a/Xabe.FFmpeg/Helpers/Conversion.Helpers.cs
+++ b/Xabe.FFmpeg/Helpers/Conversion.Helpers.cs
@@ -163,6 +163,7 @@ namespace Xabe.FFmpeg
 
             return New()
                 .AddStream(audioStream)
+                .SetAudioBitrate(string.Format("{0}K", audioStream.Bitrate / 1000))
                 .SetOutput(outputPath);
         }
 


### PR DESCRIPTION
Copy of #211 

This PR contains a workaround for issue #201

The reason the track size doubles is due to a bug in FFMPEG where the audio track length is doubled if no audio bitrate is specified. This workaround explicitly sets the bitrate of the target stream to the bitrate of the source stream so the FFMPEG bug is not triggered.