### PR TITLE
Added multiple ConversionException and UnknownDecoderException from F…

### DIFF
--- a/Xabe.FFmpeg/Exceptions/UknownDecoder.cs
+++ b/Xabe.FFmpeg/Exceptions/UknownDecoder.cs
@@ -8,7 +8,7 @@
     {
         /// <inheritdoc />
         /// <summary>
-        ///     The exception that is thrown when a FFmpeg cannot find specified hardware accelerator.
+        ///     The exception that is thrown when a FFmpeg cannot find a codec to decode the file.
         /// </summary>
         /// <param name="errorMessage">FFmpeg error output</param>
         /// <param name="inputParameters">FFmpeg input parameters</param>

--- a/Xabe.FFmpeg/FFmpegWrapper.cs
+++ b/Xabe.FFmpeg/FFmpegWrapper.cs
@@ -106,7 +106,17 @@ namespace Xabe.FFmpeg
                             return false;
                         }
 
-                        if (_outputLog.Any(x => x.Contains("Unknown decoder")))
+                        if (_outputLog.Any(x => x.Contains("Invalid NAL unit size")))
+                        {
+                            throw new ConversionException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Packet mismatch") && _outputLog.Any(y => y.Contains("Output file is empty") )))
+                        {
+                            throw new ConversionException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+                        
+                        if (_outputLog.Any(x => x.Contains("multiple fourcc not supported")))
                         {
                             throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
                         }
@@ -114,6 +124,41 @@ namespace Xabe.FFmpeg
                         if (_outputLog.Any(x => x.Contains("Unrecognized hwaccel: ")))
                         {
                             throw new HardwareAcceleratorNotFoundException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Unknown decoder")))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("asf_read_pts failed")))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Missing key frame while searching for timestamp")))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Old interlaced mode is not supported")))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Failed to open codec in avformat_find_stream_info")))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("mpeg1video") && _outputLog.Any(y => y.Contains("Output file is empty"))))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
+                        }
+
+                        if (_outputLog.Any(x => x.Contains("Frame rate very high for a muxer not efficiently supporting it") && _outputLog.Any(y => y.Contains("Output file is empty"))))
+                        {
+                            throw new UnknownDecoderException(string.Join(Environment.NewLine, _outputLog.ToArray()), args);
                         }
 
                         if (process.ExitCode != 0)

--- a/Xabe.FFmpeg/Streams/VideoStream.cs
+++ b/Xabe.FFmpeg/Streams/VideoStream.cs
@@ -239,7 +239,7 @@ namespace Xabe.FFmpeg.Streams
             {
                 if (seek > Duration)
                 {
-                    throw new ArgumentException("Seek can not be greater than video duration");
+                    throw new ArgumentException("Seek can not be greater than video duration. Seek: " + seek.TotalSeconds  + " Duration: " + Duration.TotalSeconds );
                 }
                 _seek = $"-ss {seek} ";
             }


### PR DESCRIPTION
Added multiple ConversionException and UnknownDecoderException from Ffmpeg output messages.

This is to separate invalid videos (ConversionException ) from videos that are simply not supported by Ffmpeg (UnknownDecoderException)

Changed incorrect summary in: UknownDecoder.cs 

Added extra info to ArgumentException. (There is a bug where Duration is sometimes incorrect in Conversion tasks)