### PR TITLE
Add Windows and Linux input devices

### DIFF
--- a/Xabe.FFmpeg/Enums/MediaFormat.cs
+++ b/Xabe.FFmpeg/Enums/MediaFormat.cs
@@ -95,6 +95,31 @@
         public static MediaFormat X11Grab => new MediaFormat("x11grab");
 
         /// <summary>
+        ///    ALSA
+        /// </summary>
+        public static MediaFormat ALSA => new MediaFormat("alsa");
+
+        /// <summary>
+        ///    OSS
+        /// </summary>
+        public static MediaFormat OSS => new MediaFormat("oss");
+
+        /// <summary>
+        ///    Pulse
+        /// </summary>
+        public static MediaFormat Pulse => new MediaFormat("pulse");
+
+        /// <summary>
+        ///    DShow
+        /// </summary>
+        public static MediaFormat DShow => new MediaFormat("dshow");
+
+        /// <summary>
+        ///    JACK
+        /// </summary>
+        public static MediaFormat JACK => new MediaFormat("jack");
+
+        /// <summary>
         ///     Hash
         /// </summary>
         public static MediaFormat Hash => new MediaFormat("hash");


### PR DESCRIPTION
The MediaFormat class didn't contain format definitions for several audio device input formats [listed here](https://ffmpeg.org/ffmpeg-devices.html).