### PR TITLE
Fix concurrency and memory issue with FFmpegExceptionCatcher

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Exceptions/FFmpegExceptionCatcher.cs
+++ b/src/Xabe.FFmpeg/Conversion/Exceptions/FFmpegExceptionCatcher.cs
@@ -32,7 +32,7 @@ namespace Xabe.FFmpeg.Exceptions
     {
         private static Dictionary<ExceptionCheck, Action<string, string>> Checks = new Dictionary<ExceptionCheck, Action<string, string>>();
 
-        internal FFmpegExceptionCatcher()
+        static FFmpegExceptionCatcher()
         {
             Checks.Add(new ExceptionCheck("Invalid NAL unit size"), (output, args) => throw new ConversionException(output, args));
             Checks.Add(new ExceptionCheck("Packet mismatch", true), (output, args) => throw new ConversionException(output, args));


### PR DESCRIPTION
Right now `Checks` is modified every time `FFmpegExceptionCatcher` is initialized, which resulted in a collection modified exception when another thread was iterating it. A static constructor will populate `Checks` once.