### PR TITLE
Fix Probed Framerate for videos with non constant framerate.

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -349,6 +349,7 @@ namespace Xabe.FFmpeg
         public IConversion SetInputFrameRate(double frameRate)
         {
             AddParameter($"-framerate {frameRate}", ParameterPosition.PreInput);
+            AddParameter($"-r {frameRate}", ParameterPosition.PreInput);
             return this;
         }
 
@@ -356,6 +357,7 @@ namespace Xabe.FFmpeg
         public IConversion SetFrameRate(double frameRate)
         {
             AddParameter($"-framerate {frameRate}", ParameterPosition.PostInput);
+            AddParameter($"-r {frameRate}", ParameterPosition.PostInput);
             return this;
         }
 

--- a/src/Xabe.FFmpeg/Conversion/Snippets/Video.cs
+++ b/src/Xabe.FFmpeg/Conversion/Snippets/Video.cs
@@ -220,8 +220,11 @@ namespace Xabe.FFmpeg
 
             foreach (var stream in info.Streams)
             {
-                if(!typeof(ISubtitleStream).IsAssignableFrom(stream.GetType()))
-                    conversion.AddStream(stream);
+                if (stream is IVideoStream videoStream)
+                    // PR #268 We have to force the framerate here due to an FFmpeg bug with videos > 100fps from android devices
+                    conversion.AddStream(videoStream.SetFramerate(videoStream.Framerate)); 
+                else if (stream is IAudioStream audioStream)
+                    conversion.AddStream(audioStream);
             }
 
             return conversion;

--- a/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
+++ b/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
@@ -28,8 +28,20 @@ namespace Xabe.FFmpeg
 
         private double GetVideoFramerate(ProbeModel.Stream vid)
         {
+            long frameCount = GetFrameCount(vid);
+            double duration = vid.duration;
             string[] fr = vid.r_frame_rate.Split('/');
-            return Math.Round(double.Parse(fr[0]) / double.Parse(fr[1]), 3);
+
+            if (frameCount > 0)
+                return Math.Round(frameCount / duration, 3);
+            else
+                return Math.Round(double.Parse(fr[0]) / double.Parse(fr[1]), 3);
+        }
+
+        private long GetFrameCount(ProbeModel.Stream vid)
+        {
+            long frameCount = 0;
+            return long.TryParse(vid.nb_frames, out frameCount) ? frameCount : 0;
         }
 
         private string GetVideoAspectRatio(int width, int height)

--- a/src/Xabe.FFmpeg/Probe/Model/ProbeModel.cs
+++ b/src/Xabe.FFmpeg/Probe/Model/ProbeModel.cs
@@ -31,6 +31,7 @@ namespace Xabe.FFmpeg
             public string pix_fmt { get; set; }
 
             public Tags tags { get; set; }
+            public string nb_frames { get; set; }
 
             public Disposition disposition { get; set; }
 
@@ -55,7 +56,6 @@ namespace Xabe.FFmpeg
             //            public int start_pts { get; set; }
             //            public string start_time { get; set; }
             //            public int duration_ts { get; set; }
-            //            public string nb_frames { get; set; }
         }
 
         internal class Tags

--- a/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
@@ -801,7 +801,6 @@ namespace Xabe.FFmpeg.Test
             IConversionResult conversionResult = await FFmpeg.Conversions.New()
                                                                  .AddStream(videoStream)
                                                                  .SetFrameRate(videoStream.Framerate)
-                                                                 .SetOutputFormat(Format.h264)
                                                                  .SetOutput(output)
                                                                  .Start();
 

--- a/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
@@ -790,6 +790,29 @@ namespace Xabe.FFmpeg.Test
                 FFmpeg.SetExecutablesPath(path);
             }
         }
+
+        [Fact]
+        public async Task ConvertSloMoTest()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+            IMediaInfo info = await FFmpeg.GetMediaInfo(Resources.SloMoMp4);
+            IVideoStream videoStream = info.VideoStreams.First()?.SetCodec(VideoCodec.h264);
+
+            IConversionResult conversionResult = await FFmpeg.Conversions.New()
+                                                                 .AddStream(videoStream)
+                                                                 .SetFrameRate(videoStream.Framerate)
+                                                                 .SetOutputFormat(Format.h264)
+                                                                 .SetOutput(output)
+                                                                 .Start();
+
+
+            IMediaInfo resultFile = await FFmpeg.GetMediaInfo(output);
+            IVideoStream resultVideoStream = resultFile.VideoStreams?.First();
+
+            Assert.Equal(".mp4", Path.GetExtension(resultFile.Path));
+            Assert.Equal(116.244, resultVideoStream.Framerate);
+            Assert.Equal(TimeSpan.FromSeconds(3), resultVideoStream.Duration);
+        }
     }
 }
 

--- a/test/Xabe.FFmpeg.Test/Conversion/Snippets/ConversionToFormatTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/Snippets/ConversionToFormatTests.cs
@@ -28,7 +28,7 @@ namespace Xabe.FFmpeg.Test
             IVideoStream videoStream = mediaInfo.VideoStreams.First();
             Assert.Equal("gif", videoStream.Codec);
             Assert.Equal("16:9", videoStream.Ratio);
-            Assert.Equal(24.889, videoStream.Framerate);
+            Assert.Equal(25, videoStream.Framerate);
             Assert.Equal(1280, videoStream.Width);
             Assert.Equal(720, videoStream.Height);
         }

--- a/test/Xabe.FFmpeg.Test/Conversion/Snippets/ConversionToFormatTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/Snippets/ConversionToFormatTests.cs
@@ -28,7 +28,7 @@ namespace Xabe.FFmpeg.Test
             IVideoStream videoStream = mediaInfo.VideoStreams.First();
             Assert.Equal("gif", videoStream.Codec);
             Assert.Equal("16:9", videoStream.Ratio);
-            Assert.Equal(25, videoStream.Framerate);
+            Assert.Equal(24.889, videoStream.Framerate);
             Assert.Equal(1280, videoStream.Width);
             Assert.Equal(720, videoStream.Height);
         }

--- a/test/Xabe.FFmpeg.Test/Conversion/Snippets/VideoSnippetsTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/Snippets/VideoSnippetsTests.cs
@@ -166,6 +166,25 @@ namespace Xabe.FFmpeg.Test
             Assert.Equal("h264", videoStream.Codec);
             Assert.Equal("aac", audioStream.Codec);
             Assert.Empty(mediaInfo.SubtitleStreams);
+            Assert.Equal(25, videoStream.Framerate);
+        }
+
+        [Fact]
+        public async Task BasicConversion_SloMo()
+        {
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+
+            IConversionResult result = await (await FFmpeg.Conversions.FromSnippet.Convert(Resources.SloMoMp4, output)).Start();
+
+
+            IMediaInfo mediaInfo = await FFmpeg.GetMediaInfo(output);
+            Assert.Equal(TimeSpan.FromSeconds(3), mediaInfo.Duration);
+            Assert.Single(mediaInfo.VideoStreams);
+            IVideoStream videoStream = mediaInfo.VideoStreams.First();
+            Assert.NotNull(videoStream);
+            Assert.Equal("h264", videoStream.Codec);
+            Assert.Empty(mediaInfo.SubtitleStreams);
+            Assert.Equal(116.244, videoStream.Framerate);
         }
 
         [Fact]
@@ -181,6 +200,9 @@ namespace Xabe.FFmpeg.Test
             Assert.Single(mediaInfo.VideoStreams);
             Assert.Equal(2, mediaInfo.AudioStreams.Count());
             Assert.Empty(mediaInfo.SubtitleStreams);
+            IVideoStream videoStream = mediaInfo.VideoStreams.First();
+            Assert.NotNull(videoStream);
+            Assert.Equal(24, videoStream.Framerate);
         }
 
         [Fact(Skip = "The RTSP stream is not valid anymore")]

--- a/test/Xabe.FFmpeg.Test/Probe/MediaInfoTests.cs
+++ b/test/Xabe.FFmpeg.Test/Probe/MediaInfoTests.cs
@@ -161,5 +161,15 @@ namespace Xabe.FFmpeg.Test
             Assert.NotNull(exception);
             Assert.IsType<ArgumentException>(exception);
         }
+
+        [Fact]
+        public async Task GetSloMoVideoFramerateTest()
+        {
+            IMediaInfo info = await FFmpeg.GetMediaInfo(Resources.SloMoMp4);
+            IVideoStream videoStream = info.VideoStreams.First();
+
+            Assert.Equal(116.244, videoStream.Framerate);
+            Assert.Equal(TimeSpan.FromSeconds(3), videoStream.Duration);
+        }
     }
 }

--- a/test/Xabe.FFmpeg.Test/Resources.cs
+++ b/test/Xabe.FFmpeg.Test/Resources.cs
@@ -15,6 +15,7 @@ namespace Xabe.FFmpeg.Test
         internal static readonly string TsWithAudio = GetResourceFilePath("sample.ts");
         internal static readonly string FlvWithAudio = GetResourceFilePath("sample.flv");
         internal static readonly string BunnyMp4 = GetResourceFilePath("bunny.mp4");
+        internal static readonly string SloMoMp4 = GetResourceFilePath("slomo.mp4");
         internal static readonly string Dll = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Xabe.FFmpeg.Test.dll");
 
         internal static readonly string Images = GetResourceFilePath("Images");


### PR DESCRIPTION
Fixes an issue where slow motion videos taken on certain android devices do not have a constant framerate have their framerate reported incorrectly by ffprobe. We can fix this issue by calculating the framerate ourselves by using the nb_frames and duration values returned by ffprobe. The video file included in this PR is an example of a video which suffers from this issue. Converting this video using the latest Xabe build causes FFmpeg to duplicate frames endlessly since this library reports the framerate to be 90000 FPS when the real frame rate is 116.234 FPS.

I have updated the basic conversion methods to force set the framerate to stop this issue from occurring although i don't know if there is anywhere else i need to update. 