### PR TITLE
Account for Inputs Created by InputBuilders when building Input Map

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -83,7 +83,7 @@ namespace Xabe.FFmpeg
                 builder.Append(BuildConversionParameters());
                 builder.Append(BuildStreamParameters());
                 builder.Append(BuildFilters());
-                builder.Append(BuildMap(_hasInputBuilder));
+                builder.Append(BuildMap());
                 builder.Append(_framerate);
                 builder.Append(BuildParameters(ParameterPosition.PostInput));
                 builder.Append(_outputTime);
@@ -499,11 +499,10 @@ namespace Xabe.FFmpeg
         }
 
         /// <summary>
-        ///     Create map for included streams
+        ///     Create map for included streams, including the InputBuilder if required
         /// </summary>
-        /// <param name="hasInputBuilder">Whether the conversion has an input builder specified</param>
         /// <returns>Map argument</returns>
-        private string BuildMap(bool hasInputBuilder)
+        private string BuildMap()
         {
             var builder = new StringBuilder();
             foreach (IStream stream in _streams)
@@ -513,7 +512,7 @@ namespace Xabe.FFmpeg
 
                 foreach (var source in stream.GetSource())
                 {
-                    if (hasInputBuilder)
+                    if (_hasInputBuilder)
                     {
                         // If we have an input builder we need to add one to the input file index to account for the input created by our input builder.
                         builder.Append($"-map {_inputFileMap[source] + 1}:{stream.Index} ");

--- a/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/ConversionTests.cs
@@ -620,6 +620,32 @@ namespace Xabe.FFmpeg.Test
         }
 
         [Fact]
+        public async Task BuildVideoFromImagesListAndAudioTest()
+        {
+            List<string> files = Directory.EnumerateFiles(Resources.Images).ToList();
+            string preparedFilesDir = string.Empty;
+            IMediaInfo audioInfo = await FFmpeg.GetMediaInfo(Resources.MkvWithAudio);
+            IAudioStream audioStream = audioInfo.AudioStreams.First();
+            string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);
+
+            IConversionResult conversionResult = await FFmpeg.Conversions.New()
+                                                                 .SetInputFrameRate(1)
+                                                                 .BuildVideoFromImages(files)
+                                                                 .SetFrameRate(1)
+                                                                 .SetPixelFormat(PixelFormat.yuv420p)
+                                                                 .AddStream(audioStream)
+                                                                 .SetOutput(output)
+                                                                 .Start();
+
+
+            IMediaInfo resultFile = await FFmpeg.GetMediaInfo(output);
+            Assert.Equal(TimeSpan.FromSeconds(12), resultFile.VideoStreams.First().Duration);
+            Assert.Equal(1, resultFile.VideoStreams.First().Framerate);
+            Assert.Equal("yuv420p", resultFile.VideoStreams.First().PixelFormat);
+            Assert.Single(resultFile.AudioStreams);
+        }
+
+        [Fact]
         public async Task OverwriteFilesTest()
         {
             string output = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + FileExtensions.Mp4);


### PR DESCRIPTION
Fixes #270.

This PR allows for other streams to be mapped along with a list of images defined via an InputBuilder by accounting for those inputs when building the input map.

Ping @tomaszzmuda for review. Do you have any feedback to this as it seems a little hacky for me.