### PR TITLE
Add SubtitleCodec Parameter to Subtitles Snippets

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Snippets/Subtitles.cs
+++ b/src/Xabe.FFmpeg/Conversion/Snippets/Subtitles.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xabe.FFmpeg.Streams.SubtitleStream;
 
 namespace Xabe.FFmpeg
 {
@@ -36,10 +37,11 @@ namespace Xabe.FFmpeg
         /// <param name="inputPath">Input path</param>
         /// <param name="outputPath">Output path</param>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
+        /// <param name="subtitleCodec">The Subtitle Codec to Use to Encode the Subtitles</param>
         /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
         /// <returns>Conversion result</returns>
         [Obsolete("This will be deleted in next major version. Please use FFmpeg.Conversions.FromSnippet instead of that.")]
-        public static IConversion AddSubtitle(string inputPath, string outputPath, string subtitlePath, string language = null)
+        public static IConversion AddSubtitle(string inputPath, string outputPath, string subtitlePath, SubtitleCodec subtitleCodec, string language = null)
         {
             IMediaInfo mediaInfo = FFmpeg.GetMediaInfo(inputPath).GetAwaiter().GetResult();
             IMediaInfo subtitleInfo = FFmpeg.GetMediaInfo(subtitlePath).GetAwaiter().GetResult();
@@ -50,7 +52,7 @@ namespace Xabe.FFmpeg
             return New()
                 .AddStream(mediaInfo.VideoStreams)
                 .AddStream(mediaInfo.AudioStreams)
-                .AddStream(subtitleStream)
+                .AddStream(subtitleStream.SetCodec(subtitleCodec))
                 .SetOutput(outputPath);
         }
     }

--- a/src/Xabe.FFmpeg/Conversion/Snippets/Subtitles.cs
+++ b/src/Xabe.FFmpeg/Conversion/Snippets/Subtitles.cs
@@ -37,6 +37,31 @@ namespace Xabe.FFmpeg
         /// <param name="inputPath">Input path</param>
         /// <param name="outputPath">Output path</param>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
+        /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
+        /// <returns>Conversion result</returns>
+        [Obsolete("This will be deleted in next major version. Please use FFmpeg.Conversions.FromSnippet instead of that.")]
+        public static IConversion AddSubtitle(string inputPath, string outputPath, string subtitlePath, string language = null)
+        {
+            IMediaInfo mediaInfo = FFmpeg.GetMediaInfo(inputPath).GetAwaiter().GetResult();
+            IMediaInfo subtitleInfo = FFmpeg.GetMediaInfo(subtitlePath).GetAwaiter().GetResult();
+
+            ISubtitleStream subtitleStream = subtitleInfo.SubtitleStreams.First()
+                                                         .SetLanguage(language);
+
+            return New()
+                .AddStream(mediaInfo.VideoStreams)
+                .AddStream(mediaInfo.AudioStreams)
+                .AddStream(subtitleStream.SetCodec(SubtitleCodec.copy))
+                .SetOutput(outputPath);
+        }
+
+        /// <summary>
+        ///     Add subtitle to file. It will be added as new stream so if you want to burn subtitles into video you should use
+        ///     SetSubtitles method.
+        /// </summary>
+        /// <param name="inputPath">Input path</param>
+        /// <param name="outputPath">Output path</param>
+        /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
         /// <param name="subtitleCodec">The Subtitle Codec to Use to Encode the Subtitles</param>
         /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
         /// <returns>Conversion result</returns>

--- a/src/Xabe.FFmpeg/FFmpegFacade.cs
+++ b/src/Xabe.FFmpeg/FFmpegFacade.cs
@@ -199,6 +199,21 @@ namespace Xabe.FFmpeg
         /// <param name="inputPath">Input path</param>
         /// <param name="outputPath">Output path</param>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
+        /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
+        /// <returns>Conversion result</returns>
+        public async Task<IConversion> AddSubtitle(string inputPath, string outputPath, string subtitlePath, string language = null)
+        {
+            return await Task.FromResult(Conversion.AddSubtitle(inputPath, outputPath, subtitlePath, language));
+        }
+
+
+        /// <summary>
+        ///     Add subtitle to file. It will be added as new stream so if you want to burn subtitles into video you should use
+        ///     BurnSubtitle method.
+        /// </summary>
+        /// <param name="inputPath">Input path</param>
+        /// <param name="outputPath">Output path</param>
+        /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
         /// <param name="subtitleCodec">The Subtitle Codec to Use to Encode the Subtitles</param>
         /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
         /// <returns>Conversion result</returns>

--- a/src/Xabe.FFmpeg/FFmpegFacade.cs
+++ b/src/Xabe.FFmpeg/FFmpegFacade.cs
@@ -199,11 +199,12 @@ namespace Xabe.FFmpeg
         /// <param name="inputPath">Input path</param>
         /// <param name="outputPath">Output path</param>
         /// <param name="subtitlePath">Path to subtitle file in .srt format</param>
+        /// <param name="subtitleCodec">The Subtitle Codec to Use to Encode the Subtitles</param>
         /// <param name="language">Language code in ISO 639. Example: "eng", "pol", "pl", "de", "ger"</param>
         /// <returns>Conversion result</returns>
-        public async Task<IConversion> AddSubtitle(string inputPath, string outputPath, string subtitlePath, string language = null)
+        public async Task<IConversion> AddSubtitle(string inputPath, string outputPath, string subtitlePath, SubtitleCodec subtitleCodec, string language = null)
         {
-            return await Task.FromResult(Conversion.AddSubtitle(inputPath, outputPath, subtitlePath, language));
+            return await Task.FromResult(Conversion.AddSubtitle(inputPath, outputPath, subtitlePath, subtitleCodec, language));
         }
 
         /// <summary>

--- a/src/Xabe.FFmpeg/Streams/SubtitleStream/SubtitleCodec.cs
+++ b/src/Xabe.FFmpeg/Streams/SubtitleStream/SubtitleCodec.cs
@@ -10,14 +10,69 @@ namespace Xabe.FFmpeg.Streams.SubtitleStream
     public enum SubtitleCodec
     {
         ///<summary>
+        ///      ass
+        ///</summary>
+        ass,
+
+        ///<summary>
         ///      copy
         ///</summary>
         copy,
 
         ///<summary>
-        ///      dvdsub
+        ///      dvb_subtitle
         ///</summary>
-        dvdsub,
+        dvb_subtitle,
+
+        ///<summary>
+        ///      dvd_subtitle
+        ///</summary>
+        dvd_subtitle,
+
+        ///<summary>
+        ///      hdmv_pgs_subtitle
+        ///</summary>
+        hdmv_pgs_subtitle,
+
+        ///<summary>
+        ///      hdmv_text_subtitle
+        ///</summary>
+        hdmv_text_subtitle,
+
+        ///<summary>
+        ///      jacosub
+        ///</summary>
+        jacosub,
+
+        ///<summary>
+        ///      microdvd
+        ///</summary>
+        microdvd,
+
+        ///<summary>
+        ///      mov_text
+        ///</summary>
+        mov_text,
+
+        ///<summary>
+        ///      mpl2
+        ///</summary>
+        mpl2,
+
+        ///<summary>
+        ///      pjs
+        ///</summary>
+        pjs,
+
+        ///<summary>
+        ///      realtext
+        ///</summary>
+        realtext,
+
+        ///<summary>
+        ///      sami
+        ///</summary>
+        sami,
 
         ///<summary>
         ///      srt
@@ -25,8 +80,39 @@ namespace Xabe.FFmpeg.Streams.SubtitleStream
         srt,
 
         ///<summary>
-        ///      mov_text
+        ///      ssa
         ///</summary>
-        mov_text,
+        ssa,
+
+        ///<summary>
+        ///      stl
+        ///</summary>
+        stl,
+
+        ///<summary>
+        ///      subrip
+        ///</summary>
+        subrip,
+
+        ///<summary>
+        ///      subviewer
+        ///</summary>
+        subviewer,
+
+        ///<summary>
+        ///      subviewer1
+        ///</summary>
+        subviewer1,
+
+        ///<summary>
+        ///      vplayer
+        ///</summary>
+        vplayer,
+
+        ///<summary>
+        ///      webvtt
+        ///</summary>
+        webvtt,
+
     }
 }

--- a/test/Xabe.FFmpeg.Test/Conversion/Snippets/SubtitleSnippetsTests.cs
+++ b/test/Xabe.FFmpeg.Test/Conversion/Snippets/SubtitleSnippetsTests.cs
@@ -2,19 +2,23 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Xabe.FFmpeg.Streams.SubtitleStream;
 using Xunit;
 
 namespace Xabe.FFmpeg.Test
 {
     public class SubtitleSnippetsTests
     {
-        [Fact]
-        public async Task AddSubtitleTest()
+        [Theory]
+        [InlineData(SubtitleCodec.webvtt)]
+        [InlineData(SubtitleCodec.subrip)]
+        [InlineData(SubtitleCodec.copy)]
+        public async Task AddSubtitleTest(SubtitleCodec subtitleCodec)
         {
             string output = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mkv);
             string input = Resources.MkvWithAudio;
 
-            IConversionResult result = await (await FFmpeg.Conversions.FromSnippet.AddSubtitle(input, output, Resources.SubtitleSrt))
+            IConversionResult result = await (await FFmpeg.Conversions.FromSnippet.AddSubtitle(input, output, Resources.SubtitleSrt, subtitleCodec))
                                              .Start();
 
             IMediaInfo outputInfo = await FFmpeg.GetMediaInfo(output);
@@ -22,16 +26,24 @@ namespace Xabe.FFmpeg.Test
             Assert.Single(outputInfo.SubtitleStreams);
             Assert.Single(outputInfo.VideoStreams);
             Assert.Single(outputInfo.AudioStreams);
+
+            if (subtitleCodec.ToString() == "copy")
+                Assert.Equal("subrip", outputInfo.SubtitleStreams.First().Codec);
+            else
+                Assert.Equal(subtitleCodec.ToString(), outputInfo.SubtitleStreams.First().Codec);
         }
 
-        [Fact]
-        public async Task AddSubtitleWithLanguageTest()
+        [Theory]
+        [InlineData(SubtitleCodec.webvtt)]
+        [InlineData(SubtitleCodec.subrip)]
+        [InlineData(SubtitleCodec.copy)]
+        public async Task AddSubtitleWithLanguageTest(SubtitleCodec subtitleCodec)
         {
             string output = Path.ChangeExtension(Path.GetTempFileName(), FileExtensions.Mkv);
             string input = Resources.MkvWithAudio;
 
             var language = "pol";
-            IConversionResult result = await (await FFmpeg.Conversions.FromSnippet.AddSubtitle(input, output, Resources.SubtitleSrt, language))
+            IConversionResult result = await (await FFmpeg.Conversions.FromSnippet.AddSubtitle(input, output, Resources.SubtitleSrt, subtitleCodec, language))
                                              .SetPreset(ConversionPreset.UltraFast)
                                              .Start();
 
@@ -41,8 +53,12 @@ namespace Xabe.FFmpeg.Test
             Assert.Single(outputInfo.SubtitleStreams);
             Assert.Single(outputInfo.VideoStreams);
             Assert.Single(outputInfo.AudioStreams);
-            Assert.Equal(language, outputInfo.SubtitleStreams.First()
-                                             .Language);
+            Assert.Equal(language, outputInfo.SubtitleStreams.First().Language);
+
+            if(subtitleCodec.ToString() == "copy")
+                Assert.Equal("subrip", outputInfo.SubtitleStreams.First().Codec);
+            else 
+                Assert.Equal(subtitleCodec.ToString(), outputInfo.SubtitleStreams.First().Codec);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #262 

This PR builds on the work done in #273, and adds the ability to pass in a subtitle codec in the subtitle snippets.

Ping @tomaszzmuda for review.