### PR TITLE
Add Rotation to VideoStream

### DIFF
--- a/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
+++ b/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
@@ -213,7 +213,8 @@ namespace Xabe.FFmpeg
                 Bitrate = Math.Abs(model.bit_rate) > 0.01 ? model.bit_rate : format.bit_Rate,
                 PixelFormat = model.pix_fmt,
                 Default = model.disposition?._default,
-                Forced = model.disposition?.forced
+                Forced = model.disposition?.forced,
+                Rotation = model.tags?.rotate
             });
         }
     }

--- a/src/Xabe.FFmpeg/Probe/Model/ProbeModel.cs
+++ b/src/Xabe.FFmpeg/Probe/Model/ProbeModel.cs
@@ -62,6 +62,7 @@ namespace Xabe.FFmpeg
         {
             public string language { get; set; }
             public string title { get; set; }
+            public int? rotate { get; set; }
         }
 
         internal class Disposition

--- a/src/Xabe.FFmpeg/Streams/VideoStream/IVideoStream.cs
+++ b/src/Xabe.FFmpeg/Streams/VideoStream/IVideoStream.cs
@@ -54,6 +54,11 @@ namespace Xabe.FFmpeg
         string PixelFormat { get; }
 
         /// <summary>
+        ///     Rotation angle
+        /// </summary>
+        int? Rotation { get; }
+
+        /// <summary>
         ///     Rotate video
         /// </summary>
         /// <param name="rotateDegrees">Rotate type</param>

--- a/src/Xabe.FFmpeg/Streams/VideoStream/VideoStream.cs
+++ b/src/Xabe.FFmpeg/Streams/VideoStream/VideoStream.cs
@@ -79,6 +79,9 @@ namespace Xabe.FFmpeg
         public string PixelFormat { get; internal set; }
 
         /// <inheritdoc />
+        public int? Rotation { get; internal set; }
+
+        /// <inheritdoc />
         public string Build()
         {
             var builder = new StringBuilder();


### PR DESCRIPTION
This PR exposes "rotate" tag from ffprobe output for video streams.