### PR TITLE
Pass Downloaded Bytes and Total Bytes into IProgress

### DIFF
--- a/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Xabe.FFmpeg.Extensions;
 
 namespace Xabe.FFmpeg.Downloader.Android
 {
@@ -46,14 +45,14 @@ namespace Xabe.FFmpeg.Downloader.Android
             return string.Empty;
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
         {
             OperatingSystemArchitecture arch = _operatingSystemArchitectureProvider.GetArchitecture();
 
             await GetLatestVersionForArchitecture(path, arch, progress);
         }
 
-        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<(long, long)> progress = null)
+        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<ProgressInfo> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
@@ -46,14 +46,14 @@ namespace Xabe.FFmpeg.Downloader.Android
             return string.Empty;
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<float> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
         {
             OperatingSystemArchitecture arch = _operatingSystemArchitectureProvider.GetArchitecture();
 
             await GetLatestVersionForArchitecture(path, arch, progress);
         }
 
-        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<float> progress = null)
+        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<(long, long)> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
+++ b/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
@@ -29,7 +29,7 @@ namespace Xabe.FFmpeg.Downloader
             _operatingSystemArchitectureProvider = new OperatingSystemArchitectureProvider();
         }
 
-        public abstract Task GetLatestVersion(string path, IProgress<(long, long)> progress = null);
+        public abstract Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null);
 
         protected bool CheckIfFilesExist(string path)
         {
@@ -81,7 +81,7 @@ namespace Xabe.FFmpeg.Downloader
             File.Delete(ffMpegZipPath);
         }
 
-        protected async Task<string> DownloadFile(string url, IProgress<(long, long)> progress)
+        protected async Task<string> DownloadFile(string url, IProgress<ProgressInfo> progress)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 

--- a/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
+++ b/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
@@ -29,7 +29,7 @@ namespace Xabe.FFmpeg.Downloader
             _operatingSystemArchitectureProvider = new OperatingSystemArchitectureProvider();
         }
 
-        public abstract Task GetLatestVersion(string path, IProgress<float> progress = null);
+        public abstract Task GetLatestVersion(string path, IProgress<(long, long)> progress = null);
 
         protected bool CheckIfFilesExist(string path)
         {
@@ -81,7 +81,7 @@ namespace Xabe.FFmpeg.Downloader
             File.Delete(ffMpegZipPath);
         }
 
-        protected async Task<string> DownloadFile(string url, IProgress<float> progress)
+        protected async Task<string> DownloadFile(string url, IProgress<(long, long)> progress)
         {
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 

--- a/src/Xabe.FFmpeg.Downloader/FFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/FFmpegDownloader.cs
@@ -11,7 +11,7 @@ namespace Xabe.FFmpeg.Downloader
         /// <param name="version">Determine which version of FFmpeg should be downloaded</param>
         /// <param name="progress">Progress of download</param>
         /// </summary>
-        public static async Task GetLatestVersion(FFmpegVersion version, IProgress<(long, long)> progress = null)
+        public static async Task GetLatestVersion(FFmpegVersion version, IProgress<ProgressInfo> progress = null)
         {
             await GetLatestVersion(version, null, progress);
         }
@@ -22,7 +22,7 @@ namespace Xabe.FFmpeg.Downloader
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
         /// </summary>
-        public static async Task GetLatestVersion(FFmpegVersion version, string path, IProgress<(long, long)> progress = null)
+        public static async Task GetLatestVersion(FFmpegVersion version, string path, IProgress<ProgressInfo> progress = null)
         {
             IFFmpegDownloader downloader;
             switch (version)

--- a/src/Xabe.FFmpeg.Downloader/FFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/FFmpegDownloader.cs
@@ -11,7 +11,7 @@ namespace Xabe.FFmpeg.Downloader
         /// <param name="version">Determine which version of FFmpeg should be downloaded</param>
         /// <param name="progress">Progress of download</param>
         /// </summary>
-        public static async Task GetLatestVersion(FFmpegVersion version, IProgress<float> progress = null)
+        public static async Task GetLatestVersion(FFmpegVersion version, IProgress<(long, long)> progress = null)
         {
             await GetLatestVersion(version, null, progress);
         }
@@ -22,7 +22,7 @@ namespace Xabe.FFmpeg.Downloader
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
         /// </summary>
-        public static async Task GetLatestVersion(FFmpegVersion version, string path, IProgress<float> progress = null)
+        public static async Task GetLatestVersion(FFmpegVersion version, string path, IProgress<(long, long)> progress = null)
         {
             IFFmpegDownloader downloader;
             switch (version)

--- a/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
@@ -32,7 +32,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<float> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
@@ -32,7 +32,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
@@ -11,6 +11,6 @@ namespace Xabe.FFmpeg.Downloader
         /// </summary>
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
-        Task GetLatestVersion(string path, IProgress<float> progress = null);
+        Task GetLatestVersion(string path, IProgress<(long, long)> progress = null);
     }
 }

--- a/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
@@ -11,6 +11,6 @@ namespace Xabe.FFmpeg.Downloader
         /// </summary>
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
-        Task GetLatestVersion(string path, IProgress<(long, long)> progress = null);
+        Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null);
     }
 }

--- a/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
@@ -20,7 +20,7 @@ namespace Xabe.FFmpeg.Downloader
             _linkProvider = new LinkProvider(operatingSystemProvider);
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
         {
             var latestVersion = GetLatestVersionInfo();
 
@@ -41,7 +41,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<(long, long)> progress)
+        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<ProgressInfo> progress)
         {
             Links links = _linkProvider.GetLinks(latestFFmpegBinaries);
 

--- a/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
@@ -20,7 +20,7 @@ namespace Xabe.FFmpeg.Downloader
             _linkProvider = new LinkProvider(operatingSystemProvider);
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<float> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
         {
             var latestVersion = GetLatestVersionInfo();
 
@@ -41,7 +41,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<float> progress)
+        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<(long, long)> progress)
         {
             Links links = _linkProvider.GetLinks(latestFFmpegBinaries);
 

--- a/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
@@ -33,7 +33,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
@@ -33,7 +33,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<float> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<(long, long)> progress = null)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
@@ -27,10 +27,9 @@ namespace Xabe.FFmpeg.Extensions
                         return;
                     }
 
-                    // Convert absolute progress (bytes downloaded) into relative progress (0% - 100%)
                     var relativeProgress = new Progress<(long, long)>(totalBytes => progress.Report(totalBytes));
                     // Use extension method to report progress while downloading
-                    await download.CopyToAsync(destination, 81920, relativeProgress, cancellationToken);
+                    await download.CopyToAsync(destination, contentLength.Value, 81920, relativeProgress, cancellationToken);
                     progress.Report((1L, 1L));
                 }
             }

--- a/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
@@ -10,7 +10,7 @@ namespace Xabe.FFmpeg.Extensions
 {
     public static class HttpClientExtensions
     {
-        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
+        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<ProgressInfo> progress = null, CancellationToken cancellationToken = default)
         {
             // Get the http headers first to examine the content length
             using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
@@ -27,10 +27,10 @@ namespace Xabe.FFmpeg.Extensions
                         return;
                     }
 
-                    var relativeProgress = new Progress<(long, long)>(totalBytes => progress.Report(totalBytes));
+                    var relativeProgress = new Progress<ProgressInfo>(totalBytes => progress.Report(totalBytes));
                     // Use extension method to report progress while downloading
                     await download.CopyToAsync(destination, contentLength.Value, 81920, relativeProgress, cancellationToken);
-                    progress.Report((1L, 1L));
+                    progress.Report(new ProgressInfo(1L, 1L));
                 }
             }
         }

--- a/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
@@ -10,7 +10,7 @@ namespace Xabe.FFmpeg.Extensions
 {
     public static class HttpClientExtensions
     {
-        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default)
+        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
         {
             // Get the http headers first to examine the content length
             using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
@@ -28,10 +28,10 @@ namespace Xabe.FFmpeg.Extensions
                     }
 
                     // Convert absolute progress (bytes downloaded) into relative progress (0% - 100%)
-                    var relativeProgress = new Progress<long>(totalBytes => progress.Report((float)totalBytes / contentLength.Value));
+                    var relativeProgress = new Progress<(long, long)>(totalBytes => progress.Report(totalBytes));
                     // Use extension method to report progress while downloading
                     await download.CopyToAsync(destination, 81920, relativeProgress, cancellationToken);
-                    progress.Report(1);
+                    progress.Report((1L, 1L));
                 }
             }
         }

--- a/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
@@ -5,11 +5,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+
 namespace Xabe.FFmpeg.Extensions
 {
     public static class StreamExtensions
     {
-        public static async Task CopyToAsync(this Stream source, Stream destination, long contentLength, int bufferSize, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
+        public static async Task CopyToAsync(this Stream source, Stream destination, long contentLength, int bufferSize, IProgress<ProgressInfo> progress = null, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -29,7 +30,7 @@ namespace Xabe.FFmpeg.Extensions
             {
                 await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
                 totalBytesRead += bytesRead;
-                progress?.Report((totalBytesRead, contentLength));
+                progress?.Report(new ProgressInfo(totalBytesRead, contentLength));
             }
         }
     }

--- a/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
@@ -9,7 +9,7 @@ namespace Xabe.FFmpeg.Extensions
 {
     public static class StreamExtensions
     {
-        public static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
+        public static async Task CopyToAsync(this Stream source, Stream destination, long contentLength, int bufferSize, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -29,7 +29,7 @@ namespace Xabe.FFmpeg.Extensions
             {
                 await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
                 totalBytesRead += bytesRead;
-                progress?.Report((totalBytesRead, source.Length));
+                progress?.Report((totalBytesRead, contentLength));
             }
         }
     }

--- a/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/StreamExtensions.cs
@@ -9,7 +9,7 @@ namespace Xabe.FFmpeg.Extensions
 {
     public static class StreamExtensions
     {
-        public static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<long> progress = null, CancellationToken cancellationToken = default)
+        public static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<(long, long)> progress = null, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -29,7 +29,7 @@ namespace Xabe.FFmpeg.Extensions
             {
                 await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
                 totalBytesRead += bytesRead;
-                progress?.Report(totalBytesRead);
+                progress?.Report((totalBytesRead, source.Length));
             }
         }
     }

--- a/src/Xabe.FFmpeg/ProgressInfo.cs
+++ b/src/Xabe.FFmpeg/ProgressInfo.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xabe.FFmpeg
+{
+    public class ProgressInfo
+    {
+        public long DownloadedBytes { get; set; }
+        public long TotalBytes { get; set; }
+
+        public ProgressInfo()
+        {
+
+        }
+
+        public ProgressInfo(long downloadedBytes, long totalBytes)
+        {
+            DownloadedBytes = downloadedBytes;
+            TotalBytes = totalBytes;
+        }
+    }
+}

--- a/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
+++ b/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
@@ -99,10 +99,10 @@ namespace Xabe.FFmpeg.Test
 
                 string ffmpegPath = downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath);
                 string ffprobePath = downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath);
-                IProgress<(long, long)> progress;
+                IProgress<ProgressInfo> progress;
 
                 // 1- First download
-                progress = new Progress<(long, long)>();
+                progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -110,7 +110,7 @@ namespace Xabe.FFmpeg.Test
 
                 // 2- Check updates (same version)
 
-                progress = new Progress<(long, long)>();
+                progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -124,7 +124,7 @@ namespace Xabe.FFmpeg.Test
                 };
                 downloader.SaveVersion(fFbinariesVersionInfo, FFmpeg.ExecutablesPath);
 
-                progress = new Progress<(long, long)>();
+                progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -134,7 +134,7 @@ namespace Xabe.FFmpeg.Test
 
                 File.Delete(ffmpegPath);
 
-                progress = new Progress<(long, long)>();
+                progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -144,7 +144,7 @@ namespace Xabe.FFmpeg.Test
 
                 File.Delete(ffprobePath);
 
-                progress = new Progress<(long, long)>();
+                progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -181,7 +181,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
-                IProgress<(long, long)> progress = new Progress<(long, long)>();
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -218,7 +218,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
-                IProgress<(long, long)> progress = new Progress<(long, long)>();
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -251,7 +251,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
-                IProgress<(long, long)> progress = new Progress<(long, long)>();
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
@@ -313,7 +313,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 FullFFmpegDownloader downloader = new FullFFmpegDownloader(operatingSystemProvider);
-                IProgress<(long, long)> progress = new Progress<(long, long)>();
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -372,7 +372,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
 
-                IProgress<(long, long)> progress = new Progress<(long, long)>();
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
             }
             finally

--- a/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
+++ b/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
@@ -99,10 +99,10 @@ namespace Xabe.FFmpeg.Test
 
                 string ffmpegPath = downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath);
                 string ffprobePath = downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath);
-                IProgress<float> progress;
+                IProgress<(long, long)> progress;
 
                 // 1- First download
-                progress = new Progress<float>();
+                progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -110,7 +110,7 @@ namespace Xabe.FFmpeg.Test
 
                 // 2- Check updates (same version)
 
-                progress = new Progress<float>();
+                progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -124,7 +124,7 @@ namespace Xabe.FFmpeg.Test
                 };
                 downloader.SaveVersion(fFbinariesVersionInfo, FFmpeg.ExecutablesPath);
 
-                progress = new Progress<float>();
+                progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -134,7 +134,7 @@ namespace Xabe.FFmpeg.Test
 
                 File.Delete(ffmpegPath);
 
-                progress = new Progress<float>();
+                progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -144,7 +144,7 @@ namespace Xabe.FFmpeg.Test
 
                 File.Delete(ffprobePath);
 
-                progress = new Progress<float>();
+                progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(ffmpegPath));
@@ -181,7 +181,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
-                IProgress<float> progress = new Progress<float>();
+                IProgress<(long, long)> progress = new Progress<(long, long)>();
                 await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -218,7 +218,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
-                IProgress<float> progress = new Progress<float>();
+                IProgress<(long, long)> progress = new Progress<(long, long)>();
                 await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -251,7 +251,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
-                IProgress<float> progress = new Progress<float>();
+                IProgress<(long, long)> progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
@@ -313,7 +313,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 FullFFmpegDownloader downloader = new FullFFmpegDownloader(operatingSystemProvider);
-                IProgress<float> progress = new Progress<float>();
+                IProgress<(long, long)> progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
@@ -372,7 +372,7 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
 
-                IProgress<float> progress = new Progress<float>();
+                IProgress<(long, long)> progress = new Progress<(long, long)>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
             }
             finally


### PR DESCRIPTION
Closes #289 

This PR modifies the IProgress API to take a tuple of (long, long) so both the downloaded bytes and total bytes can be passed in as described in the original issue. This allows for better monitoring of progress rather than just a percentage value.