### PR TITLE
Ffmpeg downloader retry on fail

### DIFF
--- a/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
@@ -45,14 +45,14 @@ namespace Xabe.FFmpeg.Downloader.Android
             return string.Empty;
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             OperatingSystemArchitecture arch = _operatingSystemArchitectureProvider.GetArchitecture();
 
-            await GetLatestVersionForArchitecture(path, arch, progress);
+            await GetLatestVersionForArchitecture(path, arch, progress, retries);
         }
 
-        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<ProgressInfo> progress = null)
+        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             if (!CheckIfFilesExist(path))
             {
@@ -60,7 +60,7 @@ namespace Xabe.FFmpeg.Downloader.Android
             }
 
             string link = GenerateLink(arch);
-            var fullPackZip = await DownloadFile(link, progress);
+            var fullPackZip = await DownloadFile(link, progress, retries);
 
             Extract(fullPackZip, path ?? ".");
         }

--- a/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
+++ b/src/Xabe.FFmpeg.Downloader/FFMpegDownloaderBase.cs
@@ -85,6 +85,7 @@ namespace Xabe.FFmpeg.Downloader
         {
             string tempPath = string.Empty;
             bool success = false;
+            int tryCount = 0;
 
             do
             {
@@ -93,6 +94,9 @@ namespace Xabe.FFmpeg.Downloader
                     tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
                     client.Timeout = TimeSpan.FromMinutes(5);
 
+                    // Add an exponential delay between subsequent retries 
+                    Thread.Sleep(TimeSpan.FromSeconds(30 * tryCount));
+
                     // Create a file stream to store the downloaded data.
                     // This really can be any type of writeable stream.
                     using (var file = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
@@ -100,6 +104,7 @@ namespace Xabe.FFmpeg.Downloader
                         // Use the custom extension method below to download the data.
                         // The passed progress-instance will receive the download status updates.
                         success = await client.DownloadAsync(url, file, progress, CancellationToken.None);
+                        tryCount += 1;
                     }
                 }
             }

--- a/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
@@ -32,7 +32,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             if (!CheckIfFilesExist(path))
             {
@@ -40,7 +40,7 @@ namespace Xabe.FFmpeg.Downloader
             }
 
             string link = GenerateLink();
-            var fullPackZip = await DownloadFile(link, progress);
+            var fullPackZip = await DownloadFile(link, progress, retries);
 
             Extract(fullPackZip, path ?? ".");
         }

--- a/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
@@ -11,6 +11,7 @@ namespace Xabe.FFmpeg.Downloader
         /// </summary>
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
-        Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null);
+        /// <param name="retries">Amount of times to retry downloading in the event of a failure</param>
+        Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0);
     }
 }

--- a/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
@@ -20,14 +20,14 @@ namespace Xabe.FFmpeg.Downloader
             _linkProvider = new LinkProvider(operatingSystemProvider);
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             var latestVersion = GetLatestVersionInfo();
 
             if (!CheckIfUpdateAvailable(latestVersion.Version, path) && !CheckIfFilesExist(path))
 
                 return;
-            await DownloadLatestVersion(latestVersion, path, progress);
+            await DownloadLatestVersion(latestVersion, path, progress, retries);
 
             SaveVersion(latestVersion, path);
         }
@@ -41,12 +41,12 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<ProgressInfo> progress)
+        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             Links links = _linkProvider.GetLinks(latestFFmpegBinaries);
 
-            var ffmpegZipDownloadTask = DownloadFile(links.FFmpegLink, progress);
-            var ffprobeZipDownloadTask = DownloadFile(links.FFprobeLink, progress);
+            var ffmpegZipDownloadTask = DownloadFile(links.FFmpegLink, progress, retries);
+            var ffprobeZipDownloadTask = DownloadFile(links.FFprobeLink, progress, retries);
 
             var ffmpegZip = await ffmpegZipDownloadTask;
             var ffprobeZip = await ffprobeZipDownloadTask;

--- a/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
@@ -33,7 +33,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
         {
             if (!CheckIfFilesExist(path))
             {
@@ -41,7 +41,7 @@ namespace Xabe.FFmpeg.Downloader
             }
 
             string link = GenerateLink();
-            var fullPackZip = await DownloadFile(link, progress);
+            var fullPackZip = await DownloadFile(link, progress, retries);
 
             Extract(fullPackZip, path ?? ".");
         }

--- a/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
+++ b/test/Xabe.FFmpeg.Test/Downloader/DownloaderTests.cs
@@ -83,6 +83,75 @@ namespace Xabe.FFmpeg.Test
         }
 
         [Fact]
+        internal async Task FullProcessPassedWithRetries()
+        {
+            const OperatingSystem os = OperatingSystem.Linux64;
+
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+            OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath(Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N")));
+
+                string ffmpegPath = downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath);
+                string ffprobePath = downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath);
+
+                // 1- First download
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 2- Check updates (same version)
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 3- Check updates (outdated version)
+
+                var fFbinariesVersionInfo = new FFbinariesVersionInfo
+                {
+                    Version = new Version().ToString() // "0.0"
+                };
+                downloader.SaveVersion(fFbinariesVersionInfo, FFmpeg.ExecutablesPath);
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 4- Missing ffmpeg
+
+                File.Delete(ffmpegPath);
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 5- Missing ffprobe
+
+                File.Delete(ffprobePath);
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Fact]
         internal async Task FullProcessPassedWithProgress()
         {
             const OperatingSystem os = OperatingSystem.Linux64;
@@ -156,6 +225,80 @@ namespace Xabe.FFmpeg.Test
             }
         }
 
+        [Fact]
+        internal async Task FullProcessPassedWithProgressAndRetries()
+        {
+            const OperatingSystem os = OperatingSystem.Linux64;
+
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+            OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath(Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N")));
+
+                string ffmpegPath = downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath);
+                string ffprobePath = downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath);
+                IProgress<ProgressInfo> progress;
+
+                // 1- First download
+                progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 2- Check updates (same version)
+
+                progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 3- Check updates (outdated version)
+
+                var fFbinariesVersionInfo = new FFbinariesVersionInfo
+                {
+                    Version = new Version().ToString() // "0.0"
+                };
+                downloader.SaveVersion(fFbinariesVersionInfo, FFmpeg.ExecutablesPath);
+
+                progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 4- Missing ffmpeg
+
+                File.Delete(ffmpegPath);
+
+                progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+
+                // 5- Missing ffprobe
+
+                File.Delete(ffprobePath);
+
+                progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
+
+                Assert.True(File.Exists(ffmpegPath));
+                Assert.True(File.Exists(ffprobePath));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
         [Theory]
         [InlineData(OperatingSystem.Windows64)]
         [InlineData(OperatingSystem.Windows32)]
@@ -181,8 +324,43 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
-                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
-                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
+                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystem.Windows64)]
+        [InlineData(OperatingSystem.Windows32)]
+        [InlineData(OperatingSystem.Osx64)]
+        [InlineData(OperatingSystem.Linux64)]
+        [InlineData(OperatingSystem.LinuxArm64)]
+        [InlineData(OperatingSystem.LinuxArmhf)]
+        [InlineData(OperatingSystem.Linux32)]
+        internal async Task DownloadLatestVersionWithRetriesTest(OperatingSystem os)
+        {
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+
+            var linkProvider = new LinkProvider(operatingSystemProvider);
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFbinariesVersionInfo currentVersion = JsonConvert.DeserializeObject<FFbinariesVersionInfo>(File.ReadAllText(Resources.FFbinariesInfo));
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
+                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, null, 3);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
@@ -219,7 +397,44 @@ namespace Xabe.FFmpeg.Test
                 }
                 OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
                 IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
-                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress);
+                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress, 0);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystem.Windows64)]
+        [InlineData(OperatingSystem.Windows32)]
+        [InlineData(OperatingSystem.Osx64)]
+        [InlineData(OperatingSystem.Linux64)]
+        [InlineData(OperatingSystem.LinuxArm64)]
+        [InlineData(OperatingSystem.LinuxArmhf)]
+        [InlineData(OperatingSystem.Linux32)]
+        internal async Task DownloadLatestVersionWithProgressAndRetriesTest(OperatingSystem os)
+        {
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+
+            var linkProvider = new LinkProvider(operatingSystemProvider);
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFbinariesVersionInfo currentVersion = JsonConvert.DeserializeObject<FFbinariesVersionInfo>(File.ReadAllText(Resources.FFbinariesInfo));
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                OfficialFFmpegDownloader downloader = new OfficialFFmpegDownloader(operatingSystemProvider);
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
+                await downloader.DownloadLatestVersion(currentVersion, FFmpeg.ExecutablesPath, progress, 3);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
@@ -251,8 +466,105 @@ namespace Xabe.FFmpeg.Test
                     Directory.Delete("assemblies", true);
                 }
                 AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", arch, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystemArchitecture.Arm)]
+        [InlineData(OperatingSystemArchitecture.Arm64)]
+        [InlineData(OperatingSystemArchitecture.X86)]
+        [InlineData(OperatingSystemArchitecture.X64)]
+        internal async Task DownloadLatestAndroidVersionWithRetriesTest(OperatingSystemArchitecture arch)
+        {
+            var operatingSystemArchProvider = Substitute.For<IOperatingSystemArchitectureProvider>();
+            operatingSystemArchProvider.GetArchitecture().Returns(x => arch);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFbinariesVersionInfo currentVersion = JsonConvert.DeserializeObject<FFbinariesVersionInfo>(File.ReadAllText(Resources.FFbinariesInfo));
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", arch, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystemArchitecture.Arm)]
+        [InlineData(OperatingSystemArchitecture.Arm64)]
+        [InlineData(OperatingSystemArchitecture.X86)]
+        [InlineData(OperatingSystemArchitecture.X64)]
+        internal async Task DownloadLatestAndroidVersionWithProgressTest(OperatingSystemArchitecture arch)
+        {
+            var operatingSystemArchProvider = Substitute.For<IOperatingSystemArchitectureProvider>();
+            operatingSystemArchProvider.GetArchitecture().Returns(x => arch);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFbinariesVersionInfo currentVersion = JsonConvert.DeserializeObject<FFbinariesVersionInfo>(File.ReadAllText(Resources.FFbinariesInfo));
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
                 IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", arch, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystemArchitecture.Arm)]
+        [InlineData(OperatingSystemArchitecture.Arm64)]
+        [InlineData(OperatingSystemArchitecture.X86)]
+        [InlineData(OperatingSystemArchitecture.X64)]
+        internal async Task DownloadLatestAndroidVersionWithProgressAndRetriesTest(OperatingSystemArchitecture arch)
+        {
+            var operatingSystemArchProvider = Substitute.For<IOperatingSystemArchitectureProvider>();
+            operatingSystemArchProvider.GetArchitecture().Returns(x => arch);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFbinariesVersionInfo currentVersion = JsonConvert.DeserializeObject<FFbinariesVersionInfo>(File.ReadAllText(Resources.FFbinariesInfo));
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                AndroidFFmpegDownloader downloader = new AndroidFFmpegDownloader(operatingSystemArchProvider);
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", arch, FFmpeg.ExecutablesPath)));
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", arch, FFmpeg.ExecutablesPath)));
@@ -298,6 +610,37 @@ namespace Xabe.FFmpeg.Test
         [InlineData(OperatingSystem.Windows64)]
         [InlineData(OperatingSystem.Windows32)]
         [InlineData(OperatingSystem.Osx64)]
+        internal async Task DownloadLatestFullVersionWithRetriesTest(OperatingSystem os)
+        {
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                FullFFmpegDownloader downloader = new FullFFmpegDownloader(operatingSystemProvider);
+
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystem.Windows64)]
+        [InlineData(OperatingSystem.Windows32)]
+        [InlineData(OperatingSystem.Osx64)]
         internal async Task DownloadLatestFullVersionWithProgressTest(OperatingSystem os)
         {
             var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
@@ -315,6 +658,37 @@ namespace Xabe.FFmpeg.Test
                 FullFFmpegDownloader downloader = new FullFFmpegDownloader(operatingSystemProvider);
                 IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
+
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
+                Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [InlineData(OperatingSystem.Windows64)]
+        [InlineData(OperatingSystem.Windows32)]
+        [InlineData(OperatingSystem.Osx64)]
+        internal async Task DownloadLatestFullVersionWithProgressAndRetriesTest(OperatingSystem os)
+        {
+            var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();
+            operatingSystemProvider.GetOperatingSystem().Returns(x => os);
+
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                FullFFmpegDownloader downloader = new FullFFmpegDownloader(operatingSystemProvider);
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
 
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffmpeg", os, FFmpeg.ExecutablesPath)));
                 Assert.True(File.Exists(downloader.ComputeFileDestinationPath("ffprobe", os, FFmpeg.ExecutablesPath)));
@@ -360,6 +734,27 @@ namespace Xabe.FFmpeg.Test
 
         [Theory]
         [MemberData(nameof(FFmpegDownloaders))]
+        internal async Task DownloadLatestVersion_NoOperatingSystemProviderIsSpecified_UseDefaultOne_WithRetries(IFFmpegDownloader downloader)
+        {
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, null, 3);
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FFmpegDownloaders))]
         internal async Task DownloadLatestVersion_NoOperatingSystemProviderIsSpecified_UseDefaultOne_WithProgress(IFFmpegDownloader downloader)
         {
             var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
@@ -374,6 +769,29 @@ namespace Xabe.FFmpeg.Test
 
                 IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
                 await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress);
+            }
+            finally
+            {
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FFmpegDownloaders))]
+        internal async Task DownloadLatestVersion_NoOperatingSystemProviderIsSpecified_UseDefaultOne_WithProgressAndRetries(IFFmpegDownloader downloader)
+        {
+            var ffmpegExecutablesPath = FFmpeg.ExecutablesPath;
+
+            try
+            {
+                FFmpeg.SetExecutablesPath("assemblies");
+                if (Directory.Exists("assemblies"))
+                {
+                    Directory.Delete("assemblies", true);
+                }
+
+                IProgress<ProgressInfo> progress = new Progress<ProgressInfo>();
+                await downloader.GetLatestVersion(FFmpeg.ExecutablesPath, progress, 3);
             }
             finally
             {


### PR DESCRIPTION
Close #290 

This PR adds retry functionality to the ffmpeg downloader via a new parameter to specify the number of times that the download should be retried upon failure. 

There is also an exponentially increasing delay between each retry. 