### PR TITLE
Improve downloader retries

### DIFF
--- a/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Android/AndroidFFmpegDownloader.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Xabe.FFmpeg.Downloader.Android
@@ -45,14 +40,14 @@ namespace Xabe.FFmpeg.Downloader.Android
             return string.Empty;
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             OperatingSystemArchitecture arch = _operatingSystemArchitectureProvider.GetArchitecture();
 
             await GetLatestVersionForArchitecture(path, arch, progress, retries);
         }
 
-        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<ProgressInfo> progress = null, int retries = 0)
+        protected async Task GetLatestVersionForArchitecture(string path, OperatingSystemArchitecture arch, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Full/FullFFMpegDownloader.cs
@@ -32,7 +32,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/IFFmpegDownloader.cs
@@ -12,6 +12,6 @@ namespace Xabe.FFmpeg.Downloader
         /// <param name="path">FFmpeg executables destination directory</param>
         /// <param name="progress">Progress of download</param>
         /// <param name="retries">Amount of times to retry downloading in the event of a failure</param>
-        Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0);
+        Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = FFmpegDownloaderBase.DefaultMaxRetries);
     }
 }

--- a/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Official/OfficialFFmpegDownloader.cs
@@ -20,7 +20,7 @@ namespace Xabe.FFmpeg.Downloader
             _linkProvider = new LinkProvider(operatingSystemProvider);
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             var latestVersion = GetLatestVersionInfo();
 
@@ -41,7 +41,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<ProgressInfo> progress = null, int retries = 0)
+        internal async Task DownloadLatestVersion(FFbinariesVersionInfo latestFFmpegBinaries, string path, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             Links links = _linkProvider.GetLinks(latestFFmpegBinaries);
 

--- a/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
+++ b/src/Xabe.FFmpeg.Downloader/Shared/SharedFFMpegDownloader.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Xabe.FFmpeg.Downloader
@@ -33,7 +31,7 @@ namespace Xabe.FFmpeg.Downloader
             }
         }
 
-        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = 0)
+        public override async Task GetLatestVersion(string path, IProgress<ProgressInfo> progress = null, int retries = DefaultMaxRetries)
         {
             if (!CheckIfFilesExist(path))
             {

--- a/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
@@ -23,6 +23,7 @@ namespace Xabe.FFmpeg.Extensions
                     if (progress == null || !contentLength.HasValue)
                     {
                         await download.CopyToAsync(destination);
+                        return;
                     }
 
                     var relativeProgress = new Progress<ProgressInfo>(totalBytes => progress.Report(totalBytes));

--- a/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
+++ b/src/Xabe.FFmpeg/Extensions/HttpClientExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,16 +8,14 @@ namespace Xabe.FFmpeg.Extensions
 {
     public static class HttpClientExtensions
     {
-        public static async Task<bool> DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<ProgressInfo> progress = null, CancellationToken cancellationToken = default)
+        public static async Task DownloadAsync(this HttpClient client, string requestUri, Stream destination, IProgress<ProgressInfo> progress = null, CancellationToken cancellationToken = default)
         {
             // Get the http headers first to examine the content length
             using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
             {
+                response.EnsureSuccessStatusCode();
+
                 var contentLength = response.Content.Headers.ContentLength;
-
-                if (!response.IsSuccessStatusCode)
-                    return false;
-
                 using (var download = await response.Content.ReadAsStreamAsync())
                 {
                     // Ignore progress reporting when no progress reporter was 
@@ -27,15 +23,12 @@ namespace Xabe.FFmpeg.Extensions
                     if (progress == null || !contentLength.HasValue)
                     {
                         await download.CopyToAsync(destination);
-                        return false;
                     }
 
                     var relativeProgress = new Progress<ProgressInfo>(totalBytes => progress.Report(totalBytes));
                     // Use extension method to report progress while downloading
                     await download.CopyToAsync(destination, contentLength.Value, 81920, relativeProgress, cancellationToken);
                     progress.Report(new ProgressInfo(1L, 1L));
-
-                    return true;
                 }
             }
         }


### PR DESCRIPTION
* Handle IO exceptions, including client-side errors (not just non-2xx error codes from the server)
* Proper exponential backoff
* Remove `HttpClient` timeout
* Default to 6 retries, so 7 attempts overall with the following delays: 1s, 2s, 4s, 8s, 16s, 32s, 64s
* Small improvements - unused `using`, `HttpClient` scope