### PR TITLE
Support for piping video output from FFmpeg as it is being created

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -81,6 +81,9 @@ namespace Xabe.FFmpeg
         public string OutputFilePath { get; private set; }
 
         /// <inheritdoc />
+        public PipeDescriptor? OutputPipeDescriptor { get; private set; }
+
+        /// <inheritdoc />
         public IEnumerable<IStream> Streams => _streams;
 
         /// <inheritdoc />
@@ -136,7 +139,7 @@ namespace Xabe.FFmpeg
 
         private void CreateOutputDirectoryIfNotExists()
         {
-            if (OutputFilePath == null)
+            if (OutputFilePath == null || OutputPipeDescriptor != null)
             {
                 return;
             }
@@ -264,6 +267,21 @@ namespace Xabe.FFmpeg
         {
             OutputFilePath = outputPath;
             _output = outputPath.Escape();
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IConversion PipeOutput(PipeDescriptor descriptor)
+        {
+            SetOutput($"pipe:{descriptor}");
+            OutputPipeDescriptor = descriptor;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IConversion PipeOutput()
+        {
+            PipeOutput(PipeDescriptor.stdout);
             return this;
         }
 

--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -276,17 +276,10 @@ namespace Xabe.FFmpeg
         }
 
         /// <inheritdoc />
-        public IConversion PipeOutput(PipeDescriptor descriptor)
+        public IConversion PipeOutput(PipeDescriptor descriptor = PipeDescriptor.stdout)
         {
             SetOutput($"pipe:{descriptor}");
             OutputPipeDescriptor = descriptor;
-            return this;
-        }
-
-        /// <inheritdoc />
-        public IConversion PipeOutput()
-        {
-            PipeOutput(PipeDescriptor.stdout);
             return this;
         }
 

--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -78,6 +78,9 @@ namespace Xabe.FFmpeg
         public event DataReceivedEventHandler OnDataReceived;
 
         /// <inheritdoc />
+        public event VideoDataEventHandler OnVideoDataReceived;
+
+        /// <inheritdoc />
         public string OutputFilePath { get; private set; }
 
         /// <inheritdoc />
@@ -119,6 +122,7 @@ namespace Xabe.FFmpeg
             {
                 _ffmpeg.OnProgress += OnProgress;
                 _ffmpeg.OnDataReceived += OnDataReceived;
+                _ffmpeg.OnVideoDataReceived += OnVideoDataReceived;
                 CreateOutputDirectoryIfNotExists();
                 await _ffmpeg.RunProcess(parameters, cancellationToken, _priority);
             }
@@ -126,6 +130,7 @@ namespace Xabe.FFmpeg
             {
                 _ffmpeg.OnProgress -= OnProgress;
                 _ffmpeg.OnDataReceived -= OnDataReceived;
+                _ffmpeg.OnVideoDataReceived -= OnVideoDataReceived;
                 _ffmpeg = null;
             }
 

--- a/src/Xabe.FFmpeg/Conversion/Enums/PipeDescriptor.cs
+++ b/src/Xabe.FFmpeg/Conversion/Enums/PipeDescriptor.cs
@@ -1,0 +1,9 @@
+﻿namespace Xabe.FFmpeg
+{
+    public enum PipeDescriptor
+    {
+        stdin,
+        stdout,
+        stderr
+    }
+}

--- a/src/Xabe.FFmpeg/Conversion/Events/VideoDataEventHandler.cs
+++ b/src/Xabe.FFmpeg/Conversion/Events/VideoDataEventHandler.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Xabe.FFmpeg.Events
+{
+    /// <summary>
+    ///     Info about conversion progress
+    /// </summary>
+    /// <param name="sender">Sender</param>
+    /// <param name="args">Video data</param>
+    public delegate void VideoDataEventHandler(object sender, VideoDataEventArgs args);
+
+    /// <summary>
+    ///     Video data
+    /// </summary>
+    public class VideoDataEventArgs : EventArgs
+    {
+        /// <inheritdoc />
+        public VideoDataEventArgs(byte[] data)
+        {
+            Data = data;
+        }
+
+        /// <summary>
+        ///     Binary video data
+        /// </summary>
+        public byte[] Data;
+    }
+}

--- a/src/Xabe.FFmpeg/Conversion/FFmpegWrapper.cs
+++ b/src/Xabe.FFmpeg/Conversion/FFmpegWrapper.cs
@@ -58,7 +58,7 @@ namespace Xabe.FFmpeg
                     process.BeginErrorReadLine();
                     if (pipedOutput)
                     {
-                        Task.Run(() => ProcessVideoData(process));
+                        Task.Run(() => ProcessVideoData(process, cancellationToken), cancellationToken);
                     }
                     var ctr = cancellationToken.Register(() =>
                     {
@@ -152,7 +152,7 @@ namespace Xabe.FFmpeg
             CalculateTime(e, args, processId);
         }
 
-        private void ProcessVideoData(Process process)
+        private void ProcessVideoData(Process process, CancellationToken cancellationToken)
         {
             BinaryReader br = new BinaryReader(process.StandardOutput.BaseStream);
             byte[] buffer;
@@ -161,6 +161,8 @@ namespace Xabe.FFmpeg
             {
                 VideoDataEventArgs args = new VideoDataEventArgs(buffer);
                 OnVideoDataReceived?.Invoke(this, args);
+
+                cancellationToken.ThrowIfCancellationRequested();
             }
         }
 

--- a/src/Xabe.FFmpeg/Conversion/FFmpegWrapper.cs
+++ b/src/Xabe.FFmpeg/Conversion/FFmpegWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -34,6 +34,11 @@ namespace Xabe.FFmpeg
         ///     Fires when FFmpeg process print something
         /// </summary>
         internal event DataReceivedEventHandler OnDataReceived;
+
+        /// <summary>
+        ///     Fires when FFmpeg process writes video data to stdout
+        /// </summary>
+        internal event VideoDataEventHandler OnVideoDataReceived;
 
         internal Task<bool> RunProcess(
             string args,

--- a/src/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -226,6 +226,11 @@ namespace Xabe.FFmpeg
         event DataReceivedEventHandler OnDataReceived;
 
         /// <summary>
+        ///     Fires when FFmpeg process writes video data to stdout
+        /// </summary>
+        event VideoDataEventHandler OnVideoDataReceived;
+
+        /// <summary>
         ///     Finish encoding when the shortest input stream ends. (-shortest)
         /// </summary>
         /// <param name="useShortest"></param>

--- a/src/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -161,12 +161,6 @@ namespace Xabe.FFmpeg
         IConversion PipeOutput(PipeDescriptor descriptor);
 
         /// <summary>
-        ///     Set piped output to stdout
-        /// </summary>
-        /// <returns>IConversion object</returns>
-        IConversion PipeOutput();
-
-        /// <summary>
         ///     Set overwrite output file parameter
         /// </summary>
         /// <param name="overwrite">Should be output file overwritten or not. If not overwrite and file exists conversion will throw ConversionException</param>

--- a/src/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -158,7 +158,7 @@ namespace Xabe.FFmpeg
         /// </summary>
         /// <param name="descriptor">Pipe file descriptor for FFmpeg process to use</param>
         /// <returns>IConversion object</returns>
-        IConversion PipeOutput(PipeDescriptor descriptor);
+        IConversion PipeOutput(PipeDescriptor descriptor = PipeDescriptor.stdout);
 
         /// <summary>
         ///     Set overwrite output file parameter

--- a/src/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -17,6 +17,11 @@ namespace Xabe.FFmpeg
         ///     Output file path
         /// </summary>
         string OutputFilePath { get; }
+
+        /// <summary>
+        ///     Output pipe descriptor
+        /// </summary>
+        PipeDescriptor? OutputPipeDescriptor { get;  }
 
         /// <summary>
         /// Set priority of ffmpeg process
@@ -147,6 +152,19 @@ namespace Xabe.FFmpeg
         /// <param name="outputPath">Output media file</param>
         /// <returns>IConversion object</returns>
         IConversion SetOutput(string outputPath);
+
+        /// <summary>
+        ///     Set piped output file descriptor
+        /// </summary>
+        /// <param name="descriptor">Pipe file descriptor for FFmpeg process to use</param>
+        /// <returns>IConversion object</returns>
+        IConversion PipeOutput(PipeDescriptor descriptor);
+
+        /// <summary>
+        ///     Set piped output to stdout
+        /// </summary>
+        /// <returns>IConversion object</returns>
+        IConversion PipeOutput();
 
         /// <summary>
         ///     Set overwrite output file parameter

--- a/src/Xabe.FFmpeg/Conversion/IConversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/IConversion.cs
@@ -220,7 +220,7 @@ namespace Xabe.FFmpeg
         event DataReceivedEventHandler OnDataReceived;
 
         /// <summary>
-        ///     Fires when FFmpeg process writes video data to stdout
+        ///     Fires when FFmpeg process writes video data to stdout. It requires .PipeOutput()
         /// </summary>
         event VideoDataEventHandler OnVideoDataReceived;
 


### PR DESCRIPTION
This pull request adds support for piping video output from FFmpeg to a C# stream and then exposing it in the API as an event.

Once the event is bound it will be fired every time new data is available from FFmpeg output stream. Video data is passed in via the event arguments as a byte array.

Usage is as follows:

```C#
IConversion conversion = FFmpeg.Conversions.New()
                                        .AddStream(videoStream)
                                        .SetOutputFormat(Format.mpegts)
                                        .PipeOutput();
using FileStream fs = new FileStream(output, FileMode.OpenOrCreate);
conversion.OnVideoDataReceived += (sender, args) =>
{
    fs.Write(args.Data, 0, args.Data.Length);
};

await conversion.Start();
```

The advantages of this should be obvious, more performance when needing to deal with data from FFmpeg as soon as it is created. The example above is not so good, since FFmpeg already writes to a file, but in my case, I needed to pass the data to gRPC. 

It works by telling FFmpeg to pipe the data to `stdout` by passing `pipe:1` as the output argument to FFmpeg. Then standard output redirection is enabled and standard output is read whilst FFmpeg process executes.