### PR TITLE
Fix of date time offset that was using the local time zone of the computer

### DIFF
--- a/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
+++ b/src/Xabe.FFmpeg/Probe/FFprobeWrapper.cs
@@ -156,10 +156,10 @@ namespace Xabe.FFmpeg
             {
                 mediaInfo.Size = long.Parse(infos.format.size);
             }
-
-            if (!string.IsNullOrWhiteSpace(infos.format.tags?.creation_time) && DateTime.TryParse(infos.format.tags.creation_time, out var creationdate))
+            
+            if (!string.IsNullOrWhiteSpace(infos.format.tags?.creation_time) && DateTimeOffset.TryParse(infos.format.tags.creation_time, out var creationdate))
             {
-                mediaInfo.CreationTime = creationdate;
+                mediaInfo.CreationTime = creationdate.UtcDateTime;
             }
 
             mediaInfo.VideoStreams = PrepareVideoStreams(path, streams.Where(x => x.codec_type == "video"), infos.format);


### PR DESCRIPTION
Context:
There are movies that the date is set to Linux date 0 which I detect and remove (I didn't change the library in this way because I wasn't 100% if it was appropriate) if it it the case.

TL;DR;
Otherwise, the creation date is offset some hours that depends on the local time zone.