### PR TITLE
Fix concat issue and PipeOutput issue

### DIFF
--- a/src/Xabe.FFmpeg/Conversion/Conversion.cs
+++ b/src/Xabe.FFmpeg/Conversion/Conversion.cs
@@ -285,7 +285,7 @@ namespace Xabe.FFmpeg
         /// <inheritdoc />
         public IConversion PipeOutput(PipeDescriptor descriptor = PipeDescriptor.stdout)
         {
-            SetOutput($"pipe:{descriptor}");
+            SetOutput($"pipe:{(int)descriptor}");
             OutputPipeDescriptor = descriptor;
             return this;
         }

--- a/src/Xabe.FFmpeg/Conversion/Enums/PipeDescriptor.cs
+++ b/src/Xabe.FFmpeg/Conversion/Enums/PipeDescriptor.cs
@@ -2,8 +2,8 @@
 {
     public enum PipeDescriptor
     {
-        stdin,
-        stdout,
-        stderr
+        stdin = 0,
+        stdout = 1,
+        stderr = 2
     }
 }

--- a/src/Xabe.FFmpeg/Conversion/Snippets/Video.cs
+++ b/src/Xabe.FFmpeg/Conversion/Snippets/Video.cs
@@ -186,7 +186,7 @@ namespace Xabe.FFmpeg
             for (var i = 0; i < mediaInfos.Count; i++)
             {
                 conversion.AddParameter(
-                    $"[{i}:v]scale={maxResolutionMedia.Width}:{maxResolutionMedia.Height},setdar=dar={maxResolutionMedia.Ratio},setpts=PTS-STARTPTS[v{i}]; ");
+                    $"[{i}:v]scale={maxResolutionMedia.Width}:{maxResolutionMedia.Height},setdar={maxResolutionMedia.Ratio},setpts=PTS-STARTPTS[v{i}]; ");
             }
 
             for (var i = 0; i < mediaInfos.Count; i++)


### PR DESCRIPTION
Syntax updated to be pipe:[number] as described in ffmpeg docs https://ffmpeg.org/ffmpeg-protocols.html#pipe

concat issue "setdar=dar=" changed to "setdar=" as this also raised issues in newer ffmpeg builds this is the fix as given by the author of #481 