### PR TITLE
XAB-1374: replace license link with website license agreement

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,39 @@
-[License moved to official Xabe.FFmpeg site](https://ffmpeg.xabe.net/license.html)
+# License Agreement
+
+This agreement is between you or the entity you represent and the Xabe company for any Software as published on the date of a Software purchase or renewal, terms incorporated by reference, terms applicable to other Xabe web site.
+
+If you are entering into this Agreement on behalf of an entity, such as your employer, you represent that you have the legal authority to bind that entity. If you specify a company name in connection with purchasing for or ordering a Software, you will be deemed to have placed that order and to have entered into this Agreement on behalf of that organization or company.
+
+## 1. Definitions:
+
+- **Content** documents, codes, photographs, videos, and other graphical, textual, or audio-visual content that may be subject to copyright protection that is available through the Xabe website.
+- **Customer Data** any content or other data, including all text, image files that are provided to us by, or on behalf of you, through your use of the Software for use by you or your authorized users. Customer Data does not include Submissions or any other Content or data that you submit to the Forum section or otherwise provided via the Software for public access.
+- **Software** any information, documentation, codes that Xabe made available to you under this Agreement for your support and upgrades period.
+- **Submissions** Content, code, comments, feedback, suggestions, information or materials that you provide via the Xabe website or any Software for public access (rather than for your personal use or use by your authorized users). Submissions do not include Customer Data.
+- **Company Plan** a per-company based support and upgrade period, or other Xabe granted benefit that permits access to and account services for the Software.
+- **We and Us** "We" and "us" means Xabe
+- **You and Your** "You" and "Your" means the person or entity accepting this Agreement to use the Software.
+
+## 2. Conditions and Limitations:
+
+- **Non-commercial use** You may use Software under [Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)](https://creativecommons.org/licenses/by-nc-sa/3.0/) license for non commercial projects.
+- **No Trademark License** The software license does not grant you rights to use Xabe name, logo, or trademarks.
+- **Content Distribution** If you distribute any portion of the content, you must retain all copyright, patent, trademark, and attribution notices that are present in the content.
+
+  If you distribute any portion of the content in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the content in compiled or object code form, you may only do so under a license that complies with this license.
+- **Software is licensed "as-is"** Xabe warrants and represents to you that: the Software does not infringe upon or violate any third party patent, copyright, trade secret or other proprietary or intellectual property right. For avoidance of doubt, the Software is provided as is and without any warranty and Xabe makes no other express warranties, guarantees or conditions. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose.
+- **Validity** This License Agreement is valid without signature. It becomes effective upon the user's receipt of an invoice.
+- **Developer Seat** one developer using the Xabe's library on his/her Workstation to perform any development. It does not include multiple developers sharing the library on one or more computers, even if their use is only part-time and/or is not concurrent.
+
+## 3. Software:
+
+- **Right to use** We grant you the right to access and use the Software during the support and upgrade period and only in accordance with this Agreement. After the support and upgrades period or in case of a cancelled support and upgrades period, all the license keys that were set up during the support and upgrades period remain valid.
+- **Distribution** You are not permitted to distribute Xabe Software pursuant to this Section: as a standalone product; a similar product; or as a part of any product other than your integrated product.
+- **Company Plan** Each support and upgrade period is sold for a particular or a company who is allowed to share the previously bought licenses with all of its developers who own a developer seat only excluding any third parties. Any third parties who wishes to use the products developed by the company or particular who bought the product is allowed, but cannot customize it without the Xabe agreement.
+- **Manner of use** By accepting the term of this Agreement, you may not:
+  - I) Reverse engineer, decompile, disassemble or work around technical limitations in the Software, except to the extent that applicable law permits it despite these limitations;
+  - II) Disable, tamper with or otherwise attempt to circumvent any mechanism that limits your use of the Software;
+  - III) Rent, lease, lend, resell, transfer, or sublicense any Software or portion thereof to or for third parties, except as explicitly permitted herein or in license terms that accompany any Software component;
+  - IV) Use the Software for any purpose that is unlawful or prohibited by this Agreement; or
+  - V) Use the Software in any manner that could damage, disable, overburden, or impair any Xabe Software, or the network(s) connected to any Xabe Software, or interfere with any other party's use and enjoyment of any Software.
+- **Updates** We may make changes to the Software from time to time, including: the availability of features; how long, how much or how often any given feature may be used; and feature dependencies upon other services or software.


### PR DESCRIPTION
Replaces the one-line pointer in the root `LICENSE.md` ("License moved to official Xabe.FFmpeg site") with the full License Agreement currently served at https://ffmpeg.xabe.net/license.html, converted to Markdown. One file changed: `LICENSE.md`.

## Presentation-only conversion
- Page `h2` → `#`, page `h3` section headings → `##` (heading text incl. numbering and trailing colon unchanged)
- Bold term labels in list items → `**Term**` prefix; label text unchanged
- Flat and nested lists → Markdown `-` lists; the roman numerals I)–V) stay inside the item text
- Ordinary website hyperlink → Markdown link (anchor text and href unchanged)
- The two `<p>` paragraphs inside the "Content Distribution" item → two Markdown paragraphs within the same list item
- Site chrome (site nav, header, footer, cookie-consent assets, analytics scripts, JSON-LD markup) omitted — not part of the agreement

## Content-fidelity evidence (mechanical check)
- Fresh fetch during implementation: 2026-09-02T03:47:54Z, HTTP 200, 16,064 bytes
- Raw HTML sha256: `c142382c5d892f638973f441d94ad76f65d9e4c900a5fe30314ce432786cddb9`
- Method: extracted the agreement region (from "License Agreement" to the end of "3. Software:") from the archived page, reduced source and this file to normalized token streams (whitespace collapsed; Markdown/bullet/heading markers stripped; links rendered as `text URL`), and compared the sequences.
- Result: **915/915 tokens, identical in sequence (match ratio 1.000000)** — no clause omitted, duplicated, reordered, corrected, or supplemented.
- Per-section parity (source : this file): title/introduction 107:107 · `1. Definitions:` 203:203 · `2. Conditions and Limitations:` 261:261 · `3. Software:` 340:340
- CC BY-NC-SA 3.0 link appears exactly once, target unchanged: `https://creativecommons.org/licenses/by-nc-sa/3.0/`
- Pre-existing wording kept verbatim, including its grammatical/legal quirks (e.g. "sold for a particular or a company"; "means Xabe" without a terminal period). No proofreading, interpretation, correction, or supplementation.

## Decision (flagged for owner review)
- `CHANGELOG.md:65` — the dated entry `"[License moved to official Xabe.FFmpeg site](https://github.com/tomaszzmuda/Xabe.FFmpeg/pull/342/files)"` — was left untouched: it is a historical record of that PR, not a live pointer. The live pointer existed only in `LICENSE.md` and is gone. Objection welcome at review time.

## Packaging coordination (XAB-1372, PR #496)
- #496 ships the nupkg license as `license/Xabe-License.txt` (a new file on that branch) and does not touch the root `LICENSE.md` — zero file overlap with this PR, no merge-conflict risk.
- Suggestion for a follow-up on XAB-1372: once this text is approved and merged, re-sync `license/Xabe-License.txt` from the approved migration so packages ship the authoritative copy. Packaging metadata is out of scope for this issue.

## Verification
- Fidelity check per the issue's verification list (mechanical; numbers above).
- `dotnet build Xabe.FFmpeg.sln -c Release` — build succeeded, 0 warnings, 0 errors.
- `dotnet test test/Xabe.FFmpeg.Downloader.Test -c Release --no-build` — 76/76 passed.
- `dotnet test test/Xabe.FFmpeg.Test -c Release --no-build` — 15 passed, 8 skipped, 244 failed locally: every one is `FFmpegNotFoundException: Cannot find FFmpeg in PATH` (or an assert-type cascade caused by it) — the run environment (musl container) cannot execute CI's pinned glibc FFmpeg 7.1.1 binary. Docs-only diff (the sole change) touches no product code; PR CI on ubuntu-24.04 with the pinned FFmpeg is the authoritative full-matrix run.
